### PR TITLE
Updated split_load_datasets to compile image ids with each split for later evaluation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,22 +23,63 @@ repos:
                             # Adjust this value based on your project's needs.
                             # Common values might be 100 (0.1MB) to 1024 (1MB) or more.
 
+# --- Code Formatting Hooks (Python & Notebooks) --- #
   # Add Black for code formatting
   - repo: https://github.com/psf/black
     rev: 25.1.0 
     hooks:
       - id: black
+        language: python
         # Optional: You can add args if you want to customize Black's behavior, e.g., line length
-        # args: ["--line-length=88"]
+        args: ["--line-length=88"]
         stages: [manual]
 
-  # Add nbqa black for Notebook formatting
+  # Add nbqa black and flake8 for notebook formatting
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.9.1 # Use the latest stable version of nbQA (check nbQA-dev/nbQA releases for the latest)
     hooks:
       - id: nbqa-black
+        language: python
         # nbqa hooks automatically target .ipynb files.
         # You can pass arguments to black via nbqa's --nbqa-args flag if needed.
         # For example, to set line length for black within notebooks:
-        # args: ["--nbqa-args=--line-length=88"]
+        args: ["--nbqa-args=--line-length=88"]
+        stages: [manual]
+        
+
+  # isort (Import Sorter)
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2 # Use the latest stable version (check isort's GitHub releases)
+    hooks:
+      - id: isort
+        args: ["--profile", "black"] # VERY IMPORTANT: Tells isort to use Black's profile for compatibility
+        # Optional: You can also specify line length here if it differs from Black,
+        # but --profile black usually handles this.
+        # args: ["--profile", "black", "--line-length", "88"]
+        stages: [manual]
+
+# --- Linting Hooks (Python & Notebooks) --- #
+  # Add flake8 for linting
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0 # Use the latest stable version available (check PyCQA/flake8 releases on GitHub)
+    hooks:
+      - id: flake8
+        # Optional: Add arguments to Flake8 directly here.
+        # Arguments specified here will override or add to settings in your .flake8 or pyproject.toml
+        # args:
+        #   - --max-line-length=88 # Example: enforce a specific line length
+        #   - --ignore=E203,W503  # Example: ignore specific error codes (common with Black)
+        #   - --max-complexity=10 # Example: set max cyclomatic complexity
+        args:
+          - --max-line-length=88 # Match your desired line length
+          - --ignore=E203,W503 # Common ignores when using Black (and isort)
+        stages: [manual]
+
+  # Add nbqa black and flake8 for notebook formatting
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.9.1 # Use the latest stable version of nbQA (check nbQA-dev/nbQA releases for the latest)
+    hooks:
+      - id: nbqa-flake8
+        language: python
+        args: ["--nbqa-mutate"]
         stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,10 +43,9 @@ repos:
         # nbqa hooks automatically target .ipynb files.
         # You can pass arguments to black via nbqa's --nbqa-args flag if needed.
         # For example, to set line length for black within notebooks:
-        args: ["--nbqa-args=--line-length=88"]
+        args: ["--line-length=88"]
         stages: [manual]
         
-
   # isort (Import Sorter)
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2 # Use the latest stable version (check isort's GitHub releases)
@@ -70,9 +69,10 @@ repos:
         #   - --max-line-length=88 # Example: enforce a specific line length
         #   - --ignore=E203,W503  # Example: ignore specific error codes (common with Black)
         #   - --max-complexity=10 # Example: set max cyclomatic complexity
-        args:
-          - --max-line-length=88 # Match your desired line length
-          - --ignore=E203,W503 # Common ignores when using Black (and isort)
+        # args:
+        #   - --max-line-length=88 # Match your desired line length
+        #   - --ignore=E203,W503 # Common ignores when using Black (and isort)
+        args: ["--max-line-length=88", "--ignore=E203,W503"]
         stages: [manual]
 
   # Add nbqa black and flake8 for notebook formatting
@@ -81,5 +81,5 @@ repos:
     hooks:
       - id: nbqa-flake8
         language: python
-        args: ["--nbqa-mutate"]
+        args: ["--nbqa-mutate", "--max-line-length=88", "--ignore=E203,W503"]
         stages: [manual]

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This project bridges **Computer Vision** and **Natural Language Processing**, fo
 **VTT (Vision-to-Text)** is a modular deep learning pipeline for image captioning that translates visual content into coherent, semantically meaningful natural language descriptions. It combines computer vision (CV) and natural language processing (NLP) techniques via an encoder-decoder architecture using ResNet-50 and LSTM networks.
 
 This project supports both the **[Flickr8k](https://www.kaggle.com/datasets/adityajn105/flickr8k)** and **[Flickr30k](https://www.kaggle.com/datasets/awsaf49/flickr30k-dataset)** datasets and includes tools for:
+
 - Image preprocessing & feature extraction
 - Caption tokenization, filtering, and padding
 - Training-ready sequence generation
 - Metric-based and qualitative evaluation
-
 
 ## 📁 Repository Structure
 
@@ -132,12 +132,15 @@ pre-commit install
 Important Note: Collaborators only need to run pre-commit install once per local clone of the repository.
 
 ## 📄 License
+
 MIT License — feel free to use, share, and modify.
 
 ## 🤝 Contributing
+
 Pull requests welcome! For major changes, please open an issue first to discuss what you’d like to change.
 
 ## 🧠 Project Maintainers
+
 - [Curtis Neiderer](mailto:neiderer.c@northeastern.edu)
 - [Divya Maheshkumar](maheshkumar.d@northeastern.edu)
 - [Desiree Reed](reed.des@northeastern.edu)

--- a/notebooks/data_loader_usage_example.ipynb
+++ b/notebooks/data_loader_usage_example.ipynb
@@ -81,7 +81,7 @@
     "    features_path=features_path,\n",
     "    captions_path=captions_path,\n",
     "    batch_size=64,\n",
-    "    shuffle=True\n",
+    "    shuffle=True,\n",
     ")\n",
     "\n",
     "# Iterate through a few batches to inspect the structure\n",

--- a/notebooks/lstm_decoder_training_.ipynb
+++ b/notebooks/lstm_decoder_training_.ipynb
@@ -77,7 +77,7 @@
     "import numpy as np\n",
     "import tensorflow as tf\n",
     "from tensorflow.keras import layers, Model\n",
-    "import pickle   \n"
+    "import pickle"
    ]
   },
   {
@@ -88,6 +88,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
     "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"-1\""
    ]
   },
@@ -100,13 +101,13 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "captions_path = \"./padded_sequences.npz\"        \n",
+    "captions_path = \"./padded_sequences.npz\"\n",
     "captions = np.load(captions_path, allow_pickle=True)\n",
     "caption_data = {img_id: captions[img_id] for img_id in captions.files}\n",
     "\n",
-    "image_features_path = \"./flickr8k_features.npz\" \n",
+    "image_features_path = \"./flickr8k_features.npz\"\n",
     "features_npz = np.load(image_features_path, allow_pickle=True)\n",
-    "image_features = {k: features_npz[k] for k in features_npz.files}\n"
+    "image_features = {k: features_npz[k] for k in features_npz.files}"
    ]
   },
   {
@@ -116,8 +117,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('./flickr8k_tokenizer.pkl', 'rb') as f:\n",
-    "    tokenizer = pickle.load(f)\n"
+    "with open(\"./flickr8k_tokenizer.pkl\", \"rb\") as f:\n",
+    "    tokenizer = pickle.load(f)"
    ]
   },
   {
@@ -140,8 +141,8 @@
     "EMBED_DIM = 512\n",
     "UNITS = 512\n",
     "\n",
-    "VOCAB_SIZE = len(tokenizer.word_index) + 1   \n",
-    "MAX_LEN = max(len(seq) for seqs in caption_data.values() for seq in seqs)                     "
+    "VOCAB_SIZE = len(tokenizer.word_index) + 1\n",
+    "MAX_LEN = max(len(seq) for seqs in caption_data.values() for seq in seqs)"
    ]
   },
   {
@@ -167,21 +168,21 @@
     "class ImageCaptioningModel(tf.keras.Model):\n",
     "    def __init__(self, embed_dim, units, vocab_size):\n",
     "        super().__init__()\n",
-    "        self.embedding  = layers.Embedding(vocab_size, embed_dim)\n",
-    "        self.image_proj = layers.Dense(units, activation='relu')\n",
-    "        self.lstm       = layers.LSTM(units, return_sequences=True, return_state=True)\n",
-    "        self.fc         = layers.Dense(vocab_size)\n",
+    "        self.embedding = layers.Embedding(vocab_size, embed_dim)\n",
+    "        self.image_proj = layers.Dense(units, activation=\"relu\")\n",
+    "        self.lstm = layers.LSTM(units, return_sequences=True, return_state=True)\n",
+    "        self.fc = layers.Dense(vocab_size)\n",
     "\n",
     "    def call(self, inputs):\n",
-    "        img_feat, captions = inputs          \n",
-    "        img_proj = self.image_proj(img_feat) \n",
+    "        img_feat, captions = inputs\n",
+    "        img_proj = self.image_proj(img_feat)\n",
     "        img_proj = tf.expand_dims(img_proj, 1)\n",
     "\n",
-    "        cap_emb  = self.embedding(captions)  \n",
-    "        lstm_in  = tf.concat([img_proj, cap_emb], axis=1)\n",
+    "        cap_emb = self.embedding(captions)\n",
+    "        lstm_in = tf.concat([img_proj, cap_emb], axis=1)\n",
     "\n",
     "        lstm_out, _, _ = self.lstm(lstm_in)\n",
-    "        return self.fc(lstm_out)             \n"
+    "        return self.fc(lstm_out)"
    ]
   },
   {
@@ -207,11 +208,7 @@
     }
    ],
    "source": [
-    "model = ImageCaptioningModel(\n",
-    "    embed_dim=EMBED_DIM,\n",
-    "    units=UNITS,\n",
-    "    vocab_size=VOCAB_SIZE\n",
-    ") "
+    "model = ImageCaptioningModel(embed_dim=EMBED_DIM, units=UNITS, vocab_size=VOCAB_SIZE)"
    ]
   },
   {
@@ -229,15 +226,13 @@
     }
    ],
    "source": [
-    "sample_img     = list(image_features.values())[0].reshape(1, -1)       \n",
-    "sample_caption = np.array([caption_data[list(caption_data.keys())[0]][0]]) \n",
+    "sample_img = list(image_features.values())[0].reshape(1, -1)\n",
+    "sample_caption = np.array([caption_data[list(caption_data.keys())[0]][0]])\n",
     "\n",
-    "model = ImageCaptioningModel(embed_dim=EMBED_DIM,\n",
-    "                             units=UNITS,\n",
-    "                             vocab_size=VOCAB_SIZE)\n",
+    "model = ImageCaptioningModel(embed_dim=EMBED_DIM, units=UNITS, vocab_size=VOCAB_SIZE)\n",
     "\n",
-    "output = model((sample_img, sample_caption))  \n",
-    "print(\"Output shape:\", output.shape)           "
+    "output = model((sample_img, sample_caption))\n",
+    "print(\"Output shape:\", output.shape)"
    ]
   },
   {
@@ -257,13 +252,14 @@
    "source": [
     "import tensorflow as tf\n",
     "\n",
+    "\n",
     "def make_dataset(img_feat_dict, cap_dict, batch_size=32, shuffle=True):\n",
-    "    img_ids = list(img_feat_dict.keys())               \n",
-    "    img_feats = [img_feat_dict[i] for i in img_ids]      \n",
-    "    caps      = [cap_dict[i]      for i in img_ids]      \n",
+    "    img_ids = list(img_feat_dict.keys())\n",
+    "    img_feats = [img_feat_dict[i] for i in img_ids]\n",
+    "    caps = [cap_dict[i] for i in img_ids]\n",
     "\n",
     "    flat_feats = []\n",
-    "    flat_caps  = []\n",
+    "    flat_caps = []\n",
     "    for f, five_caps in zip(img_feats, caps):\n",
     "        for c in five_caps:\n",
     "            flat_feats.append(f)\n",
@@ -275,7 +271,8 @@
     "    ds = ds.batch(batch_size).prefetch(tf.data.AUTOTUNE)\n",
     "    return ds\n",
     "\n",
-    "train_ds = make_dataset(image_features, caption_data, batch_size=64)\n"
+    "\n",
+    "train_ds = make_dataset(image_features, caption_data, batch_size=64)"
    ]
   },
   {
@@ -293,16 +290,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loss_fn   = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)\n",
+    "loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)\n",
     "optimizer = tf.keras.optimizers.Adam()\n",
+    "\n",
     "\n",
     "def masked_loss(y_true, y_pred):\n",
     "    \"\"\"\n",
     "    Ignore padding-token positions (0) when computing loss.\n",
     "    \"\"\"\n",
-    "    mask  = tf.cast(tf.not_equal(y_true, 0), tf.float32)\n",
-    "    loss  = loss_fn(y_true, y_pred) * mask\n",
-    "    return tf.reduce_sum(loss) / tf.reduce_sum(mask)\n"
+    "    mask = tf.cast(tf.not_equal(y_true, 0), tf.float32)\n",
+    "    loss = loss_fn(y_true, y_pred) * mask\n",
+    "    return tf.reduce_sum(loss) / tf.reduce_sum(mask)"
    ]
   },
   {
@@ -325,22 +323,22 @@
     "    \"\"\"\n",
     "    img_batch : (B, 2048)\n",
     "    cap_batch : (B, MAX_LEN)\n",
-    "    \n",
+    "\n",
     "    We feed caption[:-1] as input and predict caption[1:].\n",
     "    \"\"\"\n",
-    "    inp  = cap_batch[:, :-1]   \n",
-    "    targ = cap_batch[:, 1:]    \n",
+    "    inp = cap_batch[:, :-1]\n",
+    "    targ = cap_batch[:, 1:]\n",
     "\n",
     "    with tf.GradientTape() as tape:\n",
-    "        logits = model((img_batch, inp))     \n",
+    "        logits = model((img_batch, inp))\n",
     "\n",
-    "        logits = logits[:, 1:, :]           \n",
+    "        logits = logits[:, 1:, :]\n",
     "\n",
-    "        loss   = masked_loss(targ, logits)\n",
+    "        loss = masked_loss(targ, logits)\n",
     "\n",
     "    grads = tape.gradient(loss, model.trainable_variables)\n",
     "    optimizer.apply_gradients(zip(grads, model.trainable_variables))\n",
-    "    return loss\n"
+    "    return loss"
    ]
   },
   {
@@ -383,17 +381,17 @@
     }
    ],
    "source": [
-    "EPOCHS = 2          \n",
-    "STEPS  = 100        \n",
+    "EPOCHS = 2\n",
+    "STEPS = 100\n",
     "for epoch in range(EPOCHS):\n",
     "    total, steps = 0.0, 0\n",
     "\n",
     "    for img_b, cap_b in train_ds.take(STEPS):\n",
-    "        batch_loss = train_step(img_b, cap_b)   \n",
-    "        total += float(batch_loss)              \n",
+    "        batch_loss = train_step(img_b, cap_b)\n",
+    "        total += float(batch_loss)\n",
     "        steps += 1\n",
     "\n",
-    "    print(f\"Epoch {epoch+1} – avg loss: {total/steps:.4f}\")\n"
+    "    print(f\"Epoch {epoch+1} – avg loss: {total/steps:.4f}\")"
    ]
   },
   {
@@ -412,7 +410,8 @@
    "outputs": [],
    "source": [
     "import os, pathlib, datetime, pickle, numpy as np, tensorflow as tf\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"-1\"   \n"
+    "\n",
+    "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"-1\""
    ]
   },
   {
@@ -432,12 +431,12 @@
     "caps_npz = np.load(cap_path, allow_pickle=True)\n",
     "caption_data = {k: caps_npz[k] for k in caps_npz.files}\n",
     "\n",
-    "# tokenizer \n",
+    "# tokenizer\n",
     "with open(\"./flickr8k_tokenizer.pkl\", \"rb\") as f:\n",
     "    tokenizer = pickle.load(f)\n",
     "\n",
-    "VOCAB_SIZE = len(tokenizer.word_index) + 1          \n",
-    "MAX_LEN    = next(iter(caption_data.values()))[0].shape[-1] \n"
+    "VOCAB_SIZE = len(tokenizer.word_index) + 1\n",
+    "MAX_LEN = next(iter(caption_data.values()))[0].shape[-1]"
    ]
   },
   {
@@ -455,7 +454,7 @@
     }
    ],
    "source": [
-    "print(len(image_features), \"images   |   max-len =\", MAX_LEN)\n"
+    "print(len(image_features), \"images   |   max-len =\", MAX_LEN)"
    ]
   },
   {
@@ -476,11 +475,13 @@
     "import tensorflow as tf\n",
     "import numpy as np\n",
     "\n",
-    "BATCH = 4          # set 32-64 once we have the full dataset\n",
+    "BATCH = 4  # set 32-64 once we have the full dataset\n",
     "BUFFER = 8_000\n",
+    "\n",
     "\n",
     "def make_dataset(img_dict, cap_dict):\n",
     "    \"\"\"Yields (img_vec, caption_in)  → caption_out.\"\"\"\n",
+    "\n",
     "    def gen():\n",
     "        for img_id, feats in img_dict.items():\n",
     "            for cap in cap_dict[img_id]:\n",
@@ -489,25 +490,29 @@
     "    raw_ds = tf.data.Dataset.from_generator(\n",
     "        gen,\n",
     "        output_signature=(\n",
-    "            tf.TensorSpec(shape=(2048,),    dtype=tf.float32),  \n",
-    "            tf.TensorSpec(shape=(MAX_LEN,), dtype=tf.int32)    \n",
-    "        )\n",
+    "            tf.TensorSpec(shape=(2048,), dtype=tf.float32),\n",
+    "            tf.TensorSpec(shape=(MAX_LEN,), dtype=tf.int32),\n",
+    "        ),\n",
     "    )\n",
     "\n",
     "    def prep(feats, full_cap):\n",
     "        return (feats, full_cap[:-1]), full_cap[1:]\n",
     "\n",
-    "    return (raw_ds\n",
-    "              .shuffle(BUFFER)\n",
-    "              .map(prep, num_parallel_calls=tf.data.AUTOTUNE)\n",
-    "              .batch(BATCH, drop_remainder=True)        \n",
-    "              .prefetch(tf.data.AUTOTUNE))\n",
+    "    return (\n",
+    "        raw_ds.shuffle(BUFFER)\n",
+    "        .map(prep, num_parallel_calls=tf.data.AUTOTUNE)\n",
+    "        .batch(BATCH, drop_remainder=True)\n",
+    "        .prefetch(tf.data.AUTOTUNE)\n",
+    "    )\n",
+    "\n",
     "\n",
     "train_ds = make_dataset(image_features, caption_data)\n",
-    "print(\"example batch shapes:\",\n",
-    "      next(iter(train_ds.take(1)))[0][0].shape,   \n",
-    "      next(iter(train_ds.take(1)))[0][1].shape,  \n",
-    "      next(iter(train_ds.take(1)))[1].shape)      \n"
+    "print(\n",
+    "    \"example batch shapes:\",\n",
+    "    next(iter(train_ds.take(1)))[0][0].shape,\n",
+    "    next(iter(train_ds.take(1)))[0][1].shape,\n",
+    "    next(iter(train_ds.take(1)))[1].shape,\n",
+    ")"
    ]
   },
   {
@@ -518,7 +523,9 @@
    "outputs": [],
    "source": [
     "loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(\n",
-    "            from_logits=True, reduction=\"none\")\n",
+    "    from_logits=True, reduction=\"none\"\n",
+    ")\n",
+    "\n",
     "\n",
     "def masked_loss(y_true, y_pred):\n",
     "    \"\"\"\n",
@@ -526,11 +533,11 @@
     "    y_pred : (B, T+1, V)      – 19 logits (image step + T tokens)\n",
     "    We remove the first step so that time-dims match.\n",
     "    \"\"\"\n",
-    "    y_pred = y_pred[:, 1:, :]          # <--- crop image timestep\n",
-    "    mask   = tf.cast(tf.not_equal(y_true, 0), tf.float32)\n",
+    "    y_pred = y_pred[:, 1:, :]  # <--- crop image timestep\n",
+    "    mask = tf.cast(tf.not_equal(y_true, 0), tf.float32)\n",
     "\n",
-    "    loss   = loss_fn(y_true, y_pred) * mask\n",
-    "    return tf.reduce_sum(loss) / tf.reduce_sum(mask)\n"
+    "    loss = loss_fn(y_true, y_pred) * mask\n",
+    "    return tf.reduce_sum(loss) / tf.reduce_sum(mask)"
    ]
   },
   {
@@ -622,14 +629,9 @@
     }
    ],
    "source": [
-    "model.compile(optimizer=tf.keras.optimizers.Adam(1e-3),\n",
-    "              loss=masked_loss)\n",
+    "model.compile(optimizer=tf.keras.optimizers.Adam(1e-3), loss=masked_loss)\n",
     "\n",
-    "history = model.fit(\n",
-    "    train_ds,\n",
-    "    epochs=EPOCHS,\n",
-    "    callbacks=[ckpt_cb, early_cb, tb_cb]\n",
-    ")\n"
+    "history = model.fit(train_ds, epochs=EPOCHS, callbacks=[ckpt_cb, early_cb, tb_cb])"
    ]
   },
   {
@@ -639,10 +641,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('tokenizer.pkl', 'wb') as f:\n",
+    "with open(\"tokenizer.pkl\", \"wb\") as f:\n",
     "    pickle.dump(tokenizer, f)\n",
     "\n",
-    "np.savez('training_meta.npz', max_len=MAX_LEN, vocab_size=VOCAB_SIZE)\n"
+    "np.savez(\"training_meta.npz\", max_len=MAX_LEN, vocab_size=VOCAB_SIZE)"
    ]
   },
   {
@@ -663,13 +665,13 @@
     "model = ImageCaptioningModel(EMBED_DIM, UNITS, VOCAB_SIZE)\n",
     "\n",
     "\n",
-    "dummy_img  = tf.zeros((1, 2048), dtype=tf.float32)   # (B, 2048)\n",
-    "dummy_cap  = tf.zeros((1, MAX_LEN), dtype=tf.int32)  # (B, MAX_LEN)\n",
-    "_ = model((dummy_img, dummy_cap))                    # build graph\n",
+    "dummy_img = tf.zeros((1, 2048), dtype=tf.float32)  # (B, 2048)\n",
+    "dummy_cap = tf.zeros((1, MAX_LEN), dtype=tf.int32)  # (B, MAX_LEN)\n",
+    "_ = model((dummy_img, dummy_cap))  # build graph\n",
     "\n",
     "\n",
     "model.load_weights(\"checkpoints/best.weights.h5\")\n",
-    "print(\"Weights loaded ✅\")\n"
+    "print(\"Weights loaded ✅\")"
    ]
   },
   {
@@ -700,7 +702,7 @@
     "model.build(input_shape=[(None, 2048), (None, MAX_LEN)])\n",
     "\n",
     "model.load_weights(\"checkpoints/best.weights.h5\")\n",
-    "print(\"Weights loaded ✅\")\n"
+    "print(\"Weights loaded ✅\")"
    ]
   },
   {
@@ -719,11 +721,11 @@
    ],
    "source": [
     "sample_img = list(image_features.values())[0].reshape(1, -1)\n",
-    "start_seq  = [tokenizer.word_index.get(\"<start>\", 1)]\n",
-    "caption_in = tf.constant(start_seq + [0]*(MAX_LEN-1))[None, :]\n",
+    "start_seq = [tokenizer.word_index.get(\"<start>\", 1)]\n",
+    "caption_in = tf.constant(start_seq + [0] * (MAX_LEN - 1))[None, :]\n",
     "\n",
     "logits = model((sample_img, caption_in))\n",
-    "print(\"Output logits shape:\", logits.shape)   \n"
+    "print(\"Output logits shape:\", logits.shape)"
    ]
   },
   {
@@ -747,17 +749,22 @@
     "import tensorflow as tf\n",
     "import numpy as np\n",
     "\n",
-    "one_img_id      = next(iter(caption_data))           # pick any key\n",
-    "one_caption_seq = caption_data[one_img_id][0]        # first caption list\n",
-    "START_ID        = int(one_caption_seq[0])            # first token in every seq\n",
-    "END_ID          = int(one_caption_seq[-1])           # last token (padding-aware)\n",
+    "one_img_id = next(iter(caption_data))  # pick any key\n",
+    "one_caption_seq = caption_data[one_img_id][0]  # first caption list\n",
+    "START_ID = int(one_caption_seq[0])  # first token in every seq\n",
+    "END_ID = int(one_caption_seq[-1])  # last token (padding-aware)\n",
     "\n",
     "print(f\"START_ID = {START_ID}  |  END_ID = {END_ID}\")\n",
     "\n",
     "\n",
-    "def greedy_caption(model, img_vec, tokenizer,\n",
-    "                   start_id=START_ID, end_id=END_ID,\n",
-    "                   max_len=one_caption_seq.shape[-1]):\n",
+    "def greedy_caption(\n",
+    "    model,\n",
+    "    img_vec,\n",
+    "    tokenizer,\n",
+    "    start_id=START_ID,\n",
+    "    end_id=END_ID,\n",
+    "    max_len=one_caption_seq.shape[-1],\n",
+    "):\n",
     "    \"\"\"\n",
     "    Args\n",
     "        img_vec : (1, 2048) float32 numpy / tensor\n",
@@ -765,26 +772,27 @@
     "    Returns\n",
     "        string  – generated caption (without <start>/<end>)\n",
     "    \"\"\"\n",
-    "    caption_ids = [start_id]                         \n",
+    "    caption_ids = [start_id]\n",
     "    for _ in range(max_len - 1):\n",
-    "        inp = tf.constant([caption_ids + [0]*(max_len - len(caption_ids))],\n",
-    "                          dtype=tf.int32)\n",
-    "        logits = model((img_vec, inp))[:, 1:, :]     \n",
-    "        next_id = int(tf.argmax(logits[0, len(caption_ids)-1]).numpy())\n",
+    "        inp = tf.constant(\n",
+    "            [caption_ids + [0] * (max_len - len(caption_ids))], dtype=tf.int32\n",
+    "        )\n",
+    "        logits = model((img_vec, inp))[:, 1:, :]\n",
+    "        next_id = int(tf.argmax(logits[0, len(caption_ids) - 1]).numpy())\n",
     "\n",
-    "        if next_id in (end_id, 0):                   \n",
+    "        if next_id in (end_id, 0):\n",
     "            break\n",
     "        caption_ids.append(next_id)\n",
     "\n",
-    "    inv_vocab = {i:w for w,i in tokenizer.word_index.items()}\n",
-    "    words = [inv_vocab.get(i, \"<unk>\") for i in caption_ids[1:]]  \n",
+    "    inv_vocab = {i: w for w, i in tokenizer.word_index.items()}\n",
+    "    words = [inv_vocab.get(i, \"<unk>\") for i in caption_ids[1:]]\n",
     "    return \" \".join(words)\n",
     "\n",
     "\n",
     "sample_img_vec = list(image_features.values())[0].reshape(1, -1).astype(\"float32\")\n",
     "\n",
     "generated = greedy_caption(model, sample_img_vec, tokenizer)\n",
-    "print(\"\\nGenerated caption:\\n\", generated)\n"
+    "print(\"\\nGenerated caption:\\n\", generated)"
    ]
   }
  ],

--- a/notebooks/modeling_usage_example.ipynb
+++ b/notebooks/modeling_usage_example.ipynb
@@ -89,10 +89,9 @@
     "    shuffle=True,\n",
     "    buffer_size=1000,\n",
     "    seed=42,\n",
-    "    cache=True,       # Optional: speeds up performance for small datasets\n",
-    "    return_numpy=False\n",
-    ")\n",
-    "                                       "
+    "    cache=True,  # Optional: speeds up performance for small datasets\n",
+    "    return_numpy=False,\n",
+    ")"
    ]
   },
   {
@@ -357,7 +356,7 @@
     "    epochs=25,\n",
     "    val_dataset=val_ds,\n",
     "    checkpoint_path=\"../models/flickr8k_decoder_weights.weights.h5\",\n",
-    "    early_stop_patience=5\n",
+    "    early_stop_patience=5,\n",
     ")"
    ]
   },
@@ -406,7 +405,7 @@
     }
    ],
    "source": [
-    "#New plot\n",
+    "# New plot\n",
     "plot_training_history(history, metrics=[\"loss\"])"
    ]
   },
@@ -508,12 +507,12 @@
     "image_folder = f\"../data/flickr8k_images_dataset/Images\"\n",
     "\n",
     "# Define sample image ids\n",
-    "sample_image_ids = [ \n",
-    "    \"667626_18933d713e.jpg\", \n",
-    "    \"23445819_3a458716c1.jpg\", \n",
+    "sample_image_ids = [\n",
+    "    \"667626_18933d713e.jpg\",\n",
+    "    \"23445819_3a458716c1.jpg\",\n",
     "    \"27782020_4dab210360.jpg\",\n",
-    "    \"35506150_cbdb630f4f.jpg\", \n",
-    "    \"47870024_73a4481f7d.jpg\"\n",
+    "    \"35506150_cbdb630f4f.jpg\",\n",
+    "    \"47870024_73a4481f7d.jpg\",\n",
     "]\n",
     "\n",
     "display_images_with_captions(\n",
@@ -521,7 +520,7 @@
     "    model=model,\n",
     "    tokenizer=tokenizer,\n",
     "    features=features_npz,\n",
-    "    image_folder=image_folder\n",
+    "    image_folder=image_folder,\n",
     ")"
    ]
   }

--- a/notebooks/modeling_usage_example_updated.ipynb
+++ b/notebooks/modeling_usage_example_updated.ipynb
@@ -1,0 +1,655 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "71b963ef-b7a0-43a2-a9cd-4c86fc7a3fe5",
+   "metadata": {},
+   "source": [
+    "# Modeling Usage Example Notebook Updated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cf3c2fc-a406-486d-9f7d-7a25b9b37bf5",
+   "metadata": {},
+   "source": [
+    "## Setup Notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "523c13b0-5438-4807-93e9-e50df63053d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0c5129b7-9745-4835-8c88-961c5368e57a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-07-17 15:34:51.501031: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "2025-07-17 15:34:51.912499: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "E0000 00:00:1752780892.002345    1861 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "E0000 00:00:1752780892.028001    1861 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "W0000 00:00:1752780892.273321    1861 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1752780892.273355    1861 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1752780892.273357    1861 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1752780892.273358    1861 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "2025-07-17 15:34:52.297900: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
+      "To enable the following instructions: AVX2 AVX_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.keras.preprocessing.sequence import pad_sequences\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from vtt.utils.helpers import set_seed\n",
+    "from vtt.data.caption_preprocessing import load_tokenizer, load_and_clean_captions\n",
+    "from vtt.data.image_preprocessing import load_features\n",
+    "from vtt.data.data_loader import load_split_datasets\n",
+    "from vtt.models.decoder import build_decoder_model\n",
+    "from vtt.models.train import train_model\n",
+    "from vtt.models.predict import display_images_with_captions, generate_caption_greedy\n",
+    "from vtt.visualization.history_plot import plot_training_history\n",
+    "from vtt.evaluation.evaluate import evaluate_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5af7ca6b-9250-4880-841a-59e1aa3f1a92",
+   "metadata": {},
+   "source": [
+    "## Set Random Seed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b8011eb4-9b96-4fd4-8be8-6c4c5fbeb585",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Random seed set to 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set the random seed for tf, np, random, etc.\n",
+    "set_seed(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3841e1cd-d044-4290-94ef-32c13dd6bac9",
+   "metadata": {},
+   "source": [
+    "## Paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4e0c9332-c575-4ba3-ba9e-1904b6c4b169",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = \"flickr8k\"\n",
+    "features_path = f\"../data/processed/{dataset_name}_features.npz\"\n",
+    "captions_path = f\"../data/processed/{dataset_name}_padded_caption_sequences.npz\"\n",
+    "tokenizer_path = f\"../data/processed/{dataset_name}_tokenizer.json\"\n",
+    "captions_file = f\"../data/raw/{dataset_name}_captions.csv\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d30ac81d-858d-4fc0-80fb-d8b6fbe28506",
+   "metadata": {},
+   "source": [
+    "## Load Tokenizer and Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a6908550-0722-47f0-ac7c-241cb55c2bb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[INFO] Tokenizer loaded from JSON file: ../data/processed/flickr8k_tokenizer.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = load_tokenizer(tokenizer_path)\n",
+    "features = np.load(features_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea293e9e-1a7a-4f87-a33c-6f8bacfbe55e",
+   "metadata": {},
+   "source": [
+    "# Load Datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a2720a15-0ac2-4a7d-a373-5bc4bf6c7c91",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Dataset Split Sizes (number of individual samples) ---\n",
+      "Total samples loaded: 38008\n",
+      "Train samples: 28507\n",
+      "Validation samples: 5701\n",
+      "Test samples: 3800\n",
+      "----------------------------------------------------------\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-07-17 15:35:49.475808: E external/local_xla/xla/stream_executor/cuda/cuda_platform.cc:51] failed call to cuInit: INTERNAL: CUDA error: Failed call to cuInit: UNKNOWN ERROR (303)\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_ds, val_ds, test_ds = load_split_datasets(\n",
+    "    features_path=features_path,\n",
+    "    captions_path=captions_path,\n",
+    "    batch_size=64,\n",
+    "    val_split=0.15,\n",
+    "    test_split=0.10,\n",
+    "    shuffle=True,\n",
+    "    buffer_size=1000,\n",
+    "    seed=42,\n",
+    "    cache=True,\n",
+    "    return_numpy=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec50a51c-7928-4a49-ae77-6ecbbde8dfbe",
+   "metadata": {},
+   "source": [
+    "## Build Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "217ebd4c-cfb9-46b2-8707-a904ac917286",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-07-17 15:37:41.061296: W tensorflow/core/kernels/data/cache_dataset_ops.cc:916] The calling iterator did not fully read the dataset being cached. In order to avoid unexpected truncation of the dataset, the partially cached contents of the dataset  will be discarded. This can happen if you have an input pipeline similar to `dataset.cache().take(k).repeat()`. You should use `dataset.take(k).cache().repeat()` instead.\n",
+      "2025-07-17 15:37:41.062488: I tensorflow/core/framework/local_rendezvous.cc:407] Local rendezvous is aborting with status: OUT_OF_RANGE: End of sequence\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"ImageCaptionDecoder\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"ImageCaptionDecoder\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Layer (type)        </span>┃<span style=\"font-weight: bold\"> Output Shape      </span>┃<span style=\"font-weight: bold\">    Param # </span>┃<span style=\"font-weight: bold\"> Connected to      </span>┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
+       "│ image_input         │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2048</span>)      │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ -                 │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ image_dense (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>) │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       │    <span style=\"color: #00af00; text-decoration-color: #00af00\">524,544</span> │ image_input[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>] │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ caption_input       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">18</span>)        │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ -                 │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ expand_image        │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)    │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ image_dense[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>] │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)            │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ caption_embedding   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">18</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)   │  <span style=\"color: #00af00; text-decoration-color: #00af00\">2,560,000</span> │ caption_input[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]… │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Embedding</span>)         │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ merge_image_caption │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">19</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)   │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ expand_image[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">…</span> │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Concatenate</span>)       │                   │            │ caption_embeddin… │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ lstm (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">LSTM</span>)         │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">19</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)   │  <span style=\"color: #00af00; text-decoration-color: #00af00\">1,574,912</span> │ merge_image_capt… │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ output_dense        │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">19</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">10000</span>) │  <span style=\"color: #00af00; text-decoration-color: #00af00\">5,130,000</span> │ lstm[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]        │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)             │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ trim_image_output   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">18</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">10000</span>) │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ output_dense[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">…</span> │\n",
+       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)            │                   │            │                   │\n",
+       "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m   Param #\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mConnected to     \u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
+       "│ image_input         │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2048\u001b[0m)      │          \u001b[38;5;34m0\u001b[0m │ -                 │\n",
+       "│ (\u001b[38;5;33mInputLayer\u001b[0m)        │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ image_dense (\u001b[38;5;33mDense\u001b[0m) │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       │    \u001b[38;5;34m524,544\u001b[0m │ image_input[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m] │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ caption_input       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m18\u001b[0m)        │          \u001b[38;5;34m0\u001b[0m │ -                 │\n",
+       "│ (\u001b[38;5;33mInputLayer\u001b[0m)        │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ expand_image        │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1\u001b[0m, \u001b[38;5;34m256\u001b[0m)    │          \u001b[38;5;34m0\u001b[0m │ image_dense[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m] │\n",
+       "│ (\u001b[38;5;33mLambda\u001b[0m)            │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ caption_embedding   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m18\u001b[0m, \u001b[38;5;34m256\u001b[0m)   │  \u001b[38;5;34m2,560,000\u001b[0m │ caption_input[\u001b[38;5;34m0\u001b[0m]… │\n",
+       "│ (\u001b[38;5;33mEmbedding\u001b[0m)         │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ merge_image_caption │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m19\u001b[0m, \u001b[38;5;34m256\u001b[0m)   │          \u001b[38;5;34m0\u001b[0m │ expand_image[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m…\u001b[0m │\n",
+       "│ (\u001b[38;5;33mConcatenate\u001b[0m)       │                   │            │ caption_embeddin… │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ lstm (\u001b[38;5;33mLSTM\u001b[0m)         │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m19\u001b[0m, \u001b[38;5;34m512\u001b[0m)   │  \u001b[38;5;34m1,574,912\u001b[0m │ merge_image_capt… │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ output_dense        │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m19\u001b[0m, \u001b[38;5;34m10000\u001b[0m) │  \u001b[38;5;34m5,130,000\u001b[0m │ lstm[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]        │\n",
+       "│ (\u001b[38;5;33mDense\u001b[0m)             │                   │            │                   │\n",
+       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
+       "│ trim_image_output   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m18\u001b[0m, \u001b[38;5;34m10000\u001b[0m) │          \u001b[38;5;34m0\u001b[0m │ output_dense[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m…\u001b[0m │\n",
+       "│ (\u001b[38;5;33mLambda\u001b[0m)            │                   │            │                   │\n",
+       "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">9,789,456</span> (37.34 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m9,789,456\u001b[0m (37.34 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">9,789,456</span> (37.34 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m9,789,456\u001b[0m (37.34 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Get max caption length from dataset\n",
+    "for (image_tensor, input_caption, _), _ in train_ds.take(1):\n",
+    "    max_caption_len = input_caption.shape[1]\n",
+    "# Get vocab size\n",
+    "vocab_size = tokenizer.num_words\n",
+    "\n",
+    "model = build_decoder_model(vocab_size=vocab_size, max_caption_len=max_caption_len)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b492d710-53fe-4acb-8e00-3f825f870a4d",
+   "metadata": {},
+   "source": [
+    "## Train Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9a22904c-1a4e-47f3-8b6e-93dd6c20ab2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-07-17 15:37:47.963182: W tensorflow/core/kernels/data/cache_dataset_ops.cc:916] The calling iterator did not fully read the dataset being cached. In order to avoid unexpected truncation of the dataset, the partially cached contents of the dataset  will be discarded. This can happen if you have an input pipeline similar to `dataset.cache().take(k).repeat()`. You should use `dataset.take(k).cache().repeat()` instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m445/445\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m0s\u001b[0m 523ms/step - loss: 3.7264\n",
+      "Epoch 1: val_loss improved from inf to 2.42168, saving model to ../models/tmp/flickr8k_decoder_weights.weights.h5\n",
+      "\u001b[1m445/445\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m249s\u001b[0m 556ms/step - loss: 3.7248 - val_loss: 2.4217\n",
+      "Restoring model weights from the end of the best epoch: 1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "history = train_model(\n",
+    "    dataset=train_ds,\n",
+    "    model=model,\n",
+    "    epochs=1,\n",
+    "    val_dataset=val_ds,\n",
+    "    checkpoint_path=f\"../models/tmp/{dataset_name}_decoder_weights.weights.h5\",\n",
+    "    early_stop_patience=5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ebb961c-b32f-4075-b268-2e4bf05bfbb6",
+   "metadata": {},
+   "source": [
+    "## Plot Training History"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "9579d08c-2eb8-4a47-9551-91f9529960c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOb9JREFUeJzt3XlclWX+//H3AeSwH1dQkQD3BTU1KmVCRs1thrQsy9EQtWkypKz8TmHuzkiN5dTUSOXPZHKjNLfczcQycy1LxSzHBUfFpfKAKKic8/vD8UwEKHAfOJCv5+NxP4b7Otd9358bHo/mvL2u675NdrvdLgAAAAAwwM3VBQAAAACo/ggWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgBwi4mPj1dYWFi5jp00aZJMJpNzC6ogR48elclkUmpqqqtLAYBbAsECAKoIk8lUqi09Pd3VpbpEfHy8/Pz8SvzcZDJp1KhRhq8zc+ZMwggAlIOHqwsAAFwzd+7cQvvvvfeeNmzYUKS9VatWhq4za9Ys2Wy2ch07btw4vfDCC4auX1lCQ0N16dIl1ahRo0zHzZw5U3Xr1lV8fHzFFAYAv1IECwCoIoYMGVJof9u2bdqwYUOR9l+6ePGifHx8Sn2dsn7R/jkPDw95eFSP/+swmUzy8vJydRmSpLy8PHl6esrNjYkCAH69+C8cAFQjMTExioiI0O7duxUdHS0fHx+NHTtWkrR8+XL97ne/U8OGDWU2m9WkSRNNnTpVBQUFhc7xyzUW19civPLKK3rnnXfUpEkTmc1mRUZGaufOnYWOLW6NxfUpSMuWLVNERITMZrPatGmjtWvXFqk/PT1dd9xxh7y8vNSkSRO9/fbbFbZuo7g1FllZWRo2bJgaNWoks9msBg0aqF+/fjp69KgkKSwsTPv379fmzZsdU89iYmIcxx8+fFgPPfSQateuLR8fH919991atWpVkXs0mUxKS0vTuHHjFBwcLB8fH+3Zs0cmk0l///vfi9S6detWmUwmLVy40Om/BwCoLNXjn50AAA4//PCD+vTpo0ceeURDhgxRUFCQJCk1NVV+fn569tln5efnp08++UQTJkxQdna2pk+fftPzLliwQDk5OfrTn/4kk8mkv/3tb3rggQd0+PDhm45ybNmyRUuWLNGTTz4pf39//eMf/9CAAQOUmZmpOnXqSJK++uor9e7dWw0aNNDkyZNVUFCgKVOmqF69emW6/3PnzpWp/88NGDBA+/fvV2JiosLCwnTmzBlt2LBBmZmZCgsL02uvvabExET5+fnpxRdflCTH7/f06dPq0qWLLl68qKeeekp16tTRv/71L913331avHix7r///kLXmjp1qjw9PTVmzBjl5+erZcuWioqK0vz58/XMM88U6jt//nz5+/urX79+5b43AHA5OwCgSkpISLD/8j/TXbt2tUuyv/XWW0X6X7x4sUjbn/70J7uPj489Ly/P0TZ06FB7aGioY//IkSN2SfY6derYf/zxR0f78uXL7ZLsH330kaNt4sSJRWqSZPf09LQfOnTI0fb111/bJdnfeOMNR1tsbKzdx8fHfuLECUfb999/b/fw8ChyzuIMHTrULumGW0JCQpH7mjNnjt1ut9t/+uknuyT79OnTb3idNm3a2Lt27VqkffTo0XZJ9s8++8zRlpOTYw8PD7eHhYXZCwoK7Ha73b5p0ya7JHvjxo2L/E3efvttuyT7gQMHHG2XL1+2161b1z506NCb/g4AoCpjKhQAVDNms1nDhg0r0u7t7e34OScnR+fOndM999yjixcv6ttvv73peR9++GHVqlXLsX/PPfdIujb952Z69OihJk2aOPbbtWungIAAx7EFBQX6+OOP1b9/fzVs2NDRr2nTpurTp89Nz3+dl5eXNmzYUOx2M97e3vL09FR6erp++umnUl/zutWrV+vOO+/Ub37zG0ebn5+fHn/8cR09elQZGRmF+g8dOrTQ30SSBg4cKC8vL82fP9/Rtm7dOp07d+6ma2kAoKpjKhQAVDPBwcHy9PQs0r5//36NGzdOn3zyibKzswt9ZrVab3re2267rdD+9ZBRmi/hvzz2+vHXjz1z5owuXbqkpk2bFulXXFtJ3N3d1aNHj1L3/zmz2ayXX35Zzz33nIKCgnT33Xfr97//veLi4lS/fv2bHn/s2DHdddddRdqvP6Xr2LFjioiIcLSHh4cX6VuzZk3FxsZqwYIFmjp1qqRr06CCg4PVrVu3ct0XAFQVjFgAQDXzy38Fl6Tz58+ra9eu+vrrrzVlyhR99NFH2rBhg15++WVJKtXjZd3d3Yttt9vtFXpsZRo9erS+++47JScny8vLS+PHj1erVq301VdfOf1axf2dJCkuLk6HDx/W1q1blZOToxUrVmjQoEE8MQpAtceIBQD8CqSnp+uHH37QkiVLFB0d7Wg/cuSIC6v6n8DAQHl5eenQoUNFPiuurSI1adJEzz33nJ577jl9//33uv322/Xqq69q3rx5klTiE6pCQ0N18ODBIu3Xp5mFhoaW6vq9e/dWvXr1NH/+fN111126ePGiHn300XLeDQBUHfzzCAD8ClwfMfj5CMHly5c1c+ZMV5VUyPUpTMuWLdPJkycd7YcOHdKaNWsqpYaLFy8qLy+vUFuTJk3k7++v/Px8R5uvr6/Onz9f5Pi+fftqx44d+uKLLxxtubm5eueddxQWFqbWrVuXqg4PDw8NGjRIH3zwgVJTU9W2bVu1a9eufDcFAFUIIxYA8CvQpUsX1apVS0OHDtVTTz0lk8mkuXPnVqmpSJMmTdL69esVFRWlkSNHqqCgQG+++aYiIiK0Z8+eCr/+d999p+7du2vgwIFq3bq1PDw8tHTpUp0+fVqPPPKIo1+nTp2UkpKiv/zlL2ratKkCAwPVrVs3vfDCC1q4cKH69Omjp556SrVr19a//vUvHTlyRB9++GGZpjLFxcXpH//4hzZt2uSYrgYA1R3BAgB+BerUqaOVK1fqueee07hx41SrVi0NGTJE3bt3V69evVxdnqRrX9jXrFmjMWPGaPz48QoJCdGUKVN04MCBUj21yqiQkBANGjRIGzdu1Ny5c+Xh4aGWLVvqgw8+0IABAxz9JkyYoGPHjulvf/ubcnJy1LVrV3Xr1k1BQUHaunWrnn/+eb3xxhvKy8tTu3bt9NFHH+l3v/tdmWrp1KmT2rRpowMHDmjw4MHOvlUAcAmTvSr9cxYA4JbTv39/7d+/X99//72rS6lUHTp0UO3atbVx40ZXlwIATsEaCwBApbl06VKh/e+//16rV69WTEyMawpykV27dmnPnj2Ki4tzdSkA4DSMWAAAKk2DBg0UHx+vxo0b69ixY0pJSVF+fr6++uorNWvWzNXlVbh9+/Zp9+7devXVV3Xu3DkdPnxYXl5eri4LAJyCNRYAgErTu3dvLVy4UFlZWTKbzercubOmTZt2S4QKSVq8eLGmTJmiFi1aaOHChYQKAL8qjFgAAAAAMIw1FgAAAAAMI1gAAAAAMOyWW2Nhs9l08uRJ+fv7y2QyubocAAAAoMqy2+3KyclRw4YNb/oi0FsuWJw8eVIhISGuLgMAAACoNo4fP65GjRrdsM8tFyz8/f0lXfvlBAQEuLgaAAAAoOrKzs5WSEiI4zv0jdxyweL69KeAgACCBQAAAFAKpVlCwOJtAAAAAIYRLAAAAAAYRrAAAAAAYNgtt8YCAAAAxhUUFOjKlSuuLgMG1ahRQ+7u7k45F8ECAAAApWa325WVlaXz58+7uhQ4Sc2aNVW/fn3D73gjWAAAAKDUroeKwMBA+fj48MLhasxut+vixYs6c+aMJKlBgwaGzkewAAAAQKkUFBQ4QkWdOnVcXQ6cwNvbW5J05swZBQYGGpoWxeJtAAAAlMr1NRU+Pj4urgTOdP3vaXTNjEuDRUpKitq1a+d4WV3nzp21Zs2aEvvv379fAwYMUFhYmEwmk1577bXKKxYAAACSSveyNFQfzvp7ujRYNGrUSC+99JJ2796tXbt2qVu3burXr5/2799fbP+LFy+qcePGeumll1S/fv1KrhYAAABASVwaLGJjY9W3b181a9ZMzZs311//+lf5+flp27ZtxfaPjIzU9OnT9cgjj8hsNldytQAAAMA1YWFhzJ75hSqzxqKgoEBpaWnKzc1V586dnXbe/Px8ZWdnF9oAAADgOgU2u7749w9avueEvvj3Dyqw2SvsWiaT6YbbpEmTynXenTt36vHHHzdUW0xMjEaPHm3oHFWJy58KtXfvXnXu3Fl5eXny8/PT0qVL1bp1a6edPzk5WZMnT3ba+QAAAFB+a/ed0uSPMnTKmudoa2Dx0sTY1uodYexxp8U5deqU4+f3339fEyZM0MGDBx1tfn5+jp/tdrsKCgrk4XHzr8j16tVzbqG/Ai4fsWjRooX27Nmj7du3a+TIkRo6dKgyMjKcdv6kpCRZrVbHdvz4caedGwAAAKW3dt8pjZz3ZaFQIUlZ1jyNnPel1u47VcKR5Ve/fn3HZrFYZDKZHPvffvut/P39tWbNGnXq1Elms1lbtmzRv//9b/Xr109BQUHy8/NTZGSkPv7440Ln/eVUKJPJpP/3//6f7r//fvn4+KhZs2ZasWKFodo//PBDtWnTRmazWWFhYXr11VcLfT5z5kw1a9ZMXl5eCgoK0oMPPuj4bPHixWrbtq28vb1Vp04d9ejRQ7m5uYbquRmXBwtPT081bdpUnTp1UnJystq3b6/XX3/daec3m82Op05d3wAAAGCc3W7XxctXS7Xl5F3RxBX7Vdykp+ttk1ZkKCfvSqnOZ7c7b/rUCy+8oJdeekkHDhxQu3btdOHCBfXt21cbN27UV199pd69eys2NlaZmZk3PM/kyZM1cOBAffPNN+rbt68GDx6sH3/8sVw17d69WwMHDtQjjzyivXv3atKkSRo/frxSU1MlSbt27dJTTz2lKVOm6ODBg1q7dq2io6MlXRulGTRokIYPH64DBw4oPT1dDzzwgFN/Z8Vx+VSoX7LZbMrPz3d1GQAAALiJS1cK1HrCOqecyy4pKztPbSetL1X/jCm95OPpnK+yU6ZM0b333uvYr127ttq3b+/Ynzp1qpYuXaoVK1Zo1KhRJZ4nPj5egwYNkiRNmzZN//jHP7Rjxw717t27zDXNmDFD3bt31/jx4yVJzZs3V0ZGhqZPn674+HhlZmbK19dXv//97+Xv76/Q0FB16NBB0rVgcfXqVT3wwAMKDQ2VJLVt27bMNZSVS0cskpKS9Omnn+ro0aPau3evkpKSlJ6ersGDB0uS4uLilJSU5Oh/+fJl7dmzR3v27NHly5d14sQJ7dmzR4cOHXLVLQAAAKCau+OOOwrtX7hwQWPGjFGrVq1Us2ZN+fn56cCBAzcdsWjXrp3jZ19fXwUEBOjMmTPlqunAgQOKiooq1BYVFaXvv/9eBQUFuvfeexUaGqrGjRvr0Ucf1fz583Xx4kVJUvv27dW9e3e1bdtWDz30kGbNmqWffvqpXHWUhUtHLM6cOaO4uDidOnVKFotF7dq107p16xyJMTMzU25u/8s+J0+edCQxSXrllVf0yiuvqGvXrkpPT6/s8gEAAG5p3jXclTGlV6n67jjyo+Ln7Lxpv9RhkbozvHapru0svr6+hfbHjBmjDRs26JVXXlHTpk3l7e2tBx98UJcvX77heWrUqFFo32QyyWazOa3On/P399eXX36p9PR0rV+/XhMmTNCkSZO0c+dO1axZUxs2bNDWrVu1fv16vfHGG3rxxRe1fft2hYeHV0g9kouDxezZs2/4+S/DQlhYWIXPDQMAAEDpmEymUk9HuqdZPTWweCnLmlfsOguTpPoWL93TrJ7c3Vz7Zu/PP/9c8fHxuv/++yVdG8E4evRopdbQqlUrff7550Xqat68udzdr4UqDw8P9ejRQz169NDEiRNVs2ZNffLJJ3rggQdkMpkUFRWlqKgoTZgwQaGhoVq6dKmeffbZCqu5yq2xAAAAwK+Pu5tJE2Nba+S8L2WSCoWL6zFiYmxrl4cKSWrWrJmWLFmi2NhYmUwmjR8/vsJGHs6ePas9e/YUamvQoIGee+45RUZGaurUqXr44Yf1xRdf6M0339TMmTMlSStXrtThw4cVHR2tWrVqafXq1bLZbGrRooW2b9+ujRs3qmfPngoMDNT27dt19uxZtWrVqkLu4TqXPxUKAAAAt4beEQ2UMqSj6lu8CrXXt3gpZUjHCnmPRXnMmDFDtWrVUpcuXRQbG6tevXqpY8eOFXKtBQsWqEOHDoW2WbNmqWPHjvrggw+UlpamiIgITZgwQVOmTFF8fLwkqWbNmlqyZIm6deumVq1a6a233tLChQvVpk0bBQQE6NNPP1Xfvn3VvHlzjRs3Tq+++qr69OlTIfdwncl+i80tys7OlsVikdVq5dGzAAAAZZCXl6cjR44oPDxcXl5eNz+gBAU2u3Yc+VFncvIU6O+lO8NrV4mRilvVjf6uZfnuzFQoAAAAVCp3N5M6N6nj6jLgZEyFAgAAAGAYwQIAAACAYQQLAAAAAIYRLAAAAAAYRrAAAAAAYBjBAgAAAIBhBAsAAAAAhhEsAAAAABhGsAAAAABuIiYmRqNHj3Z1GVUawQIAAACVy1YgHflM2rv42v/aCirsUrGxserdu3exn3322WcymUz65ptvDF8nNTVVNWvWNHye6szD1QUAAADgFpKxQlr7vJR98n9tAQ2l3i9Lre9z+uVGjBihAQMG6D//+Y8aNWpU6LM5c+bojjvuULt27Zx+3VsRIxYAAACoHBkrpA/iCocKSco+da09Y4XTL/n73/9e9erVU2pqaqH2CxcuaNGiRRoxYoR++OEHDRo0SMHBwfLx8VHbtm21cOFCp9aRmZmpfv36yc/PTwEBARo4cKBOnz7t+Pzrr7/Wb3/7W/n7+ysgIECdOnXSrl27JEnHjh1TbGysatWqJV9fX7Vp00arV692an3OwIgFAAAAysdul65cLF1fW4G05s+S7MWdSJLp2khG4xjJzf3m56vhI5lMN+3m4eGhuLg4paam6sUXX5Tpv8csWrRIBQUFGjRokC5cuKBOnTrp+eefV0BAgFatWqVHH31UTZo00Z133lm6+7sBm83mCBWbN2/W1atXlZCQoIcffljp6emSpMGDB6tDhw5KSUmRu7u79uzZoxo1akiSEhISdPnyZX366afy9fVVRkaG/Pz8DNflbAQLAIDLFdjs2nHkR53JyVOgv5fuDK8td7ebf2EA4GJXLkrTGjrpZPZrIxkvhZSu+9iTkqdvqboOHz5c06dP1+bNmxUTEyPp2jSoAQMGyGKxyGKxaMyYMY7+iYmJWrdunT744AOnBIuNGzdq7969OnLkiEJCrt3fe++9pzZt2mjnzp2KjIxUZmam/u///k8tW7aUJDVr1sxxfGZmpgYMGKC2bdtKkho3bmy4popAsAAAuNTafac0+aMMnbLmOdoaWLw0Mba1ekc0cGFlAH4tWrZsqS5duujdd99VTEyMDh06pM8++0xTpkyRJBUUFGjatGn64IMPdOLECV2+fFn5+fny8fFxyvUPHDigkJAQR6iQpNatW6tmzZo6cOCAIiMj9eyzz+qxxx7T3Llz1aNHDz300ENq0qSJJOmpp57SyJEjtX79evXo0UMDBgyokutCCBYAAJdZu++URs77ssjEiCxrnkbO+1IpQzoSLoCqrIbPtZGD0ji2VZr/4M37DV4shXYp3bXLYMSIEUpMTNQ///lPzZkzR02aNFHXrl0lSdOnT9frr7+u1157TW3btpWvr69Gjx6ty5cvl+kaRkyaNEl/+MMftGrVKq1Zs0YTJ05UWlqa7r//fj322GPq1auXVq1apfXr1ys5OVmvvvqqEhMTK62+0mDxNgDAJQpsdk3+KKPE2daSNPmjDBXYiusBoEowma5NRyrN1qTbtac/qaRpjiYpIPhav9KcrxTrK35u4MCBcnNz04IFC/Tee+9p+PDhjvUWn3/+ufr166chQ4aoffv2aty4sb777jtjv5ufadWqlY4fP67jx4872jIyMnT+/Hm1bt3a0da8eXM988wzWr9+vR544AHNmTPH8VlISIieeOIJLVmyRM8995xmzZrltPqchRELAIBL7DjyY6HpT79kl3TKmqcdR35U5yZ1Kq8wABXDzf3aI2U/iNO1cPHzfzT4b0jo/VLpFm6Xg5+fnx5++GElJSUpOztb8fHxjs+aNWumxYsXa+vWrapVq5ZmzJih06dPF/rSXxoFBQXas2dPoTaz2awePXqobdu2Gjx4sF577TVdvXpVTz75pLp27ao77rhDly5d0v/93//pwQcfVHh4uP7zn/9o586dGjBggCRp9OjR6tOnj5o3b66ffvpJmzZtUqtWrYz+SpyOEQsAgEucySk5VJSnH4BqoPV90sD3pIBfTHEMaHitvQLeY/FzI0aM0E8//aRevXqpYcP/LTofN26cOnbsqF69eikmJkb169dX//79y3z+CxcuqEOHDoW22NhYmUwmLV++XLVq1VJ0dLR69Oihxo0b6/3335ckubu764cfflBcXJyaN2+ugQMHqk+fPpo8ebKka4ElISFBrVq1Uu/evdW8eXPNnDnTKb8TZzLZ7fZbaow5OztbFotFVqtVAQEBri4HAG5ZX/z7Bw2ate2m/Rb+8W5GLIAqIi8vT0eOHFF4eLi8vLzKfyJbwbU1FxdOS35B19ZUVNBIBW7uRn/Xsnx3ZioUAMAl7gyvrQYWL2VZ84pdZ2GSVN9y7dGzAH5l3Nyl8HtcXQWczKVToVJSUtSuXTsFBAQoICBAnTt31po1a254zKJFi9SyZUt5eXmpbdu2VfKtgwCAm3N3M2li7LX5y79cgnl9f2Jsa95nAQDVhEuDRaNGjfTSSy9p9+7d2rVrl7p166Z+/fpp//79xfbfunWrBg0apBEjRuirr75S//791b9/f+3bt6+SKwcAOEPviAZKGdJR9S2Fh97rW7x41CwAVDNVbo1F7dq1NX36dI0YMaLIZw8//LByc3O1cuVKR9vdd9+t22+/XW+99Vapzs8aCwCoenjzNlA9OG2NBaqUX90ai4KCAi1atEi5ubnq3LlzsX2++OILPfvss4XaevXqpWXLlpV43vz8fOXn5zv2s7OznVIvAMB53N1MLNAGgGrO5Y+b3bt3r/z8/GQ2m/XEE09o6dKlJT4zOCsrS0FBQYXagoKClJWVVeL5k5OTZbFYHNvPX6UOAACAsrPZbK4uAU7krL+ny0csWrRooT179shqtWrx4sUaOnSoNm/eXOYXkpQkKSmp0ChHdnY24QIAAKAcPD095ebmppMnT6pevXry9PR0vL0a1Y/dbtfly5d19uxZubm5ydPT09D5XB4sPD091bRpU0lSp06dtHPnTr3++ut6++23i/StX7++Tp8+Xajt9OnTql+/fonnN5vNMpvNzi0aAADgFuTm5qbw8HCdOnVKJ0+edHU5cBIfHx/ddtttcnMzNpnJ5cHil2w2W6E1ET/XuXNnbdy4UaNHj3a0bdiwocQ1GQAAAHAuT09P3Xbbbbp69aoKCgpcXQ4Mcnd3l4eHh1NGnlwaLJKSktSnTx/ddtttysnJ0YIFC5Senq5169ZJkuLi4hQcHKzk5GRJ0tNPP62uXbvq1Vdf1e9+9zulpaVp165deuedd1x5GwAAALcUk8mkGjVqqEaNGq4uBVWIS4PFmTNnFBcXp1OnTslisahdu3Zat26d7r33XklSZmZmoSGZLl26aMGCBRo3bpzGjh2rZs2aadmyZYqIiHDVLQAAAABQFXyPRUXjPRYAAABA6ZTlu7PLHzcLAAAAoPojWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAxzabBITk5WZGSk/P39FRgYqP79++vgwYM3PObKlSuaMmWKmjRpIi8vL7Vv315r166tpIoBAAAAFMelwWLz5s1KSEjQtm3btGHDBl25ckU9e/ZUbm5uiceMGzdOb7/9tt544w1lZGToiSee0P3336+vvvqqEisHAAAA8HMmu91ud3UR1509e1aBgYHavHmzoqOji+3TsGFDvfjii0pISHC0DRgwQN7e3po3b95Nr5GdnS2LxSKr1aqAgACn1Q4AAAD82pTlu3OVWmNhtVolSbVr1y6xT35+vry8vAq1eXt7a8uWLRVaGwAAAICSebi6gOtsNptGjx6tqKgoRURElNivV69emjFjhqKjo9WkSRNt3LhRS5YsUUFBQbH98/PzlZ+f79jPzs52eu0AAADAra7KjFgkJCRo3759SktLu2G/119/Xc2aNVPLli3l6empUaNGadiwYXJzK/5WkpOTZbFYHFtISEhFlA8AAADc0qpEsBg1apRWrlypTZs2qVGjRjfsW69ePS1btky5ubk6duyYvv32W/n5+alx48bF9k9KSpLVanVsx48fr4hbAAAAAG5pLp0KZbfblZiYqKVLlyo9PV3h4eGlPtbLy0vBwcG6cuWKPvzwQw0cOLDYfmazWWaz2VklAwAAACiGS4NFQkKCFixYoOXLl8vf319ZWVmSJIvFIm9vb0lSXFycgoODlZycLEnavn27Tpw4odtvv10nTpzQpEmTZLPZ9Oc//9ll9wEAAADc6lwaLFJSUiRJMTExhdrnzJmj+Ph4SVJmZmah9RN5eXkaN26cDh8+LD8/P/Xt21dz585VzZo1K6lqAAAAAL9Upd5jURl4jwUAAABQOtX2PRYAAAAAqieCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCXBovk5GRFRkbK399fgYGB6t+/vw4ePHjT41577TW1aNFC3t7eCgkJ0TPPPKO8vLxKqBgAAABAcVwaLDZv3qyEhARt27ZNGzZs0JUrV9SzZ0/l5uaWeMyCBQv0wgsvaOLEiTpw4IBmz56t999/X2PHjq3EygEAAAD8nIcrL7527dpC+6mpqQoMDNTu3bsVHR1d7DFbt25VVFSU/vCHP0iSwsLCNGjQIG3fvr3C6wUAAABQvCq1xsJqtUqSateuXWKfLl26aPfu3dqxY4ck6fDhw1q9erX69u1bKTUCAAAAKMqlIxY/Z7PZNHr0aEVFRSkiIqLEfn/4wx907tw5/eY3v5HdbtfVq1f1xBNPlDgVKj8/X/n5+Y797Oxsp9cOAAAA3OqqzIhFQkKC9u3bp7S0tBv2S09P17Rp0zRz5kx9+eWXWrJkiVatWqWpU6cW2z85OVkWi8WxhYSEVET5AAAAwC3NZLfb7a4uYtSoUVq+fLk+/fRThYeH37DvPffco7vvvlvTp093tM2bN0+PP/64Lly4IDe3wlmpuBGLkJAQWa1WBQQEOPdGAAAAgF+R7OxsWSyWUn13dulUKLvdrsTERC1dulTp6ek3DRWSdPHixSLhwd3d3XG+XzKbzTKbzc4pGAAAAECxXBosEhIStGDBAi1fvlz+/v7KysqSJFksFnl7e0uS4uLiFBwcrOTkZElSbGysZsyYoQ4dOuiuu+7SoUOHNH78eMXGxjoCBgAAAIDK5dJgkZKSIkmKiYkp1D5nzhzFx8dLkjIzMwuNUIwbN04mk0njxo3TiRMnVK9ePcXGxuqvf/1rZZUNAAAA4BeqxBqLylSWeWIAAADAraws352rzFOhAAAAAFRfBAsAAAAAhhEsAAAAABhGsAAAAABgWLmCxc6dO7V9+/Yi7du3b9euXbsMFwUAAACgeilXsEhISNDx48eLtJ84cUIJCQmGiwIAAABQvZQrWGRkZKhjx45F2jt06KCMjAzDRQEAAACoXsoVLMxms06fPl2k/dSpU/LwcOk79wAAAAC4QLmCRc+ePZWUlCSr1epoO3/+vMaOHat7773XacUBAAAAqB7KNbzwyiuvKDo6WqGhoerQoYMkac+ePQoKCtLcuXOdWiAAAACAqq9cwSI4OFjffPON5s+fr6+//lre3t4aNmyYBg0apBo1aji7RgAAAABVXLkXRPj6+urxxx93Zi0AAAAAqqlSB4sVK1aoT58+qlGjhlasWHHDvvfdd5/hwgAAAABUHya73W4vTUc3NzdlZWUpMDBQbm4lr/k2mUwqKChwWoHOlp2dLYvFIqvVqoCAAFeXAwAAAFRZZfnuXOoRC5vNVuzPAAAAAFDmx81euXJF3bt31/fff18R9QAAAACohsocLGrUqKFvvvmmImoBAAAAUE2V6wV5Q4YM0ezZs51dCwAAAIBqqlyPm7169areffddffzxx+rUqZN8fX0LfT5jxgynFAcAAACgeihXsNi3b586duwoSfruu++cWhAAAACA6qdcwWLTpk3OrgMAAABANVauNRbDhw9XTk5Okfbc3FwNHz7ccFEAAAAAqpdyBYt//etfunTpUpH2S5cu6b333jNcFAAAAIDqpUxTobKzs2W322W325WTkyMvLy/HZwUFBVq9erUCAwOdXiQAAACAqq1MwaJmzZoymUwymUxq3rx5kc9NJpMmT57stOIAAAAAVA9lChabNm2S3W5Xt27d9OGHH6p27dqOzzw9PRUaGqqGDRs6vUgAAAAAVVuZgkXXrl0lSUeOHNFtt90mk8lk6OLJyclasmSJvv32W3l7e6tLly56+eWX1aJFixKPiYmJ0ebNm4u09+3bV6tWrTJUDwAAAIDyKdfi7dDQUG3ZskVDhgxRly5ddOLECUnS3LlztWXLllKfZ/PmzUpISNC2bdu0YcMGXblyRT179lRubm6JxyxZskSnTp1ybPv27ZO7u7seeuih8twKAAAAACco13ssPvzwQz366KMaPHiwvvzyS+Xn50uSrFarpk2bptWrV5fqPGvXri20n5qaqsDAQO3evVvR0dHFHvPz6VeSlJaWJh8fH4IFAAAA4ELlGrH4y1/+orfeekuzZs1SjRo1HO1RUVH68ssvy12M1WqVVDQ83Mjs2bP1yCOPyNfXt9jP8/PzlZ2dXWgDAAAA4FzlChYHDx4sdkTBYrHo/Pnz5SrEZrNp9OjRioqKUkRERKmO2bFjh/bt26fHHnusxD7JycmyWCyOLSQkpFz1AQAAAChZuYJF/fr1dejQoSLtW7ZsUePGjctVSEJCgvbt26e0tLRSHzN79my1bdtWd955Z4l9kpKSZLVaHdvx48fLVR8AAACAkpUrWPzxj3/U008/re3bt8tkMunkyZOaP3++xowZo5EjR5b5fKNGjdLKlSu1adMmNWrUqFTH5ObmKi0tTSNGjLhhP7PZrICAgEIbAAAAAOcq1+LtF154QTabTd27d9fFixcVHR0ts9msMWPGKDExsdTnsdvtSkxM1NKlS5Wenq7w8PBSH7to0SLl5+dryJAh5bkFAAAAAE5kstvt9vIefPnyZR06dEgXLlxQ69at5efnV6bjn3zySS1YsEDLly8v9O4Ki8Uib29vSVJcXJyCg4OVnJxc6Nh77rlHwcHBZZo6JUnZ2dmyWCyyWq2MXgAAAAA3UJbvzmUasRg+fHip+r377rul6peSkiLp2kvvfm7OnDmKj4+XJGVmZsrNrfCMrYMHD2rLli1av359qa4DAAAAoGKVacTCzc1NoaGh6tChg2502NKlS51SXEVgxAIAAAAonQobsRg5cqQWLlyoI0eOaNiwYRoyZEiZ3jkBAAAA4NepTE+F+uc//6lTp07pz3/+sz766COFhIRo4MCBWrdu3Q1HMAAAAAD8uhlavH3s2DGlpqbqvffe09WrV7V///4yL+CubEyFAgAAAEqnLN+dy/UeC8fBbm4ymUyy2+0qKCgwcioAAAAA1ViZg0V+fr4WLlyoe++9V82bN9fevXv15ptvKjMzs8qPVgAAAACoGGVavP3kk08qLS1NISEhGj58uBYuXKi6detWVG0AAAAAqokyP272tttuU4cOHWQymUrst2TJEqcUVxFYYwEAAACUToU9bjYuLu6GgQIAAADAralMwSI1NbWCygAAAABQnRl6KhQAAAAASAQLAAAAAE5AsAAAAABgGMECAAAAgGEECwAAAACGESwAAAAAGEawAAAAAGAYwQIAAACAYQQLAAAAAIYRLAAAAAAYRrAAAAAAYBjBAgAAAIBhBAsAAAAAhhEsAAAAABhGsAAAAABgGMECAAAAgGEuDRbJycmKjIyUv7+/AgMD1b9/fx08ePCmx50/f14JCQlq0KCBzGazmjdvrtWrV1dCxQAAAACK4+HKi2/evFkJCQmKjIzU1atXNXbsWPXs2VMZGRny9fUt9pjLly/r3nvvVWBgoBYvXqzg4GAdO3ZMNWvWrNziAQAAADi4NFisXbu20H5qaqoCAwO1e/duRUdHF3vMu+++qx9//FFbt25VjRo1JElhYWEVXSoAAACAG6hSayysVqskqXbt2iX2WbFihTp37qyEhAQFBQUpIiJC06ZNU0FBQWWVCQAAAOAXXDpi8XM2m02jR49WVFSUIiIiSux3+PBhffLJJxo8eLBWr16tQ4cO6cknn9SVK1c0ceLEIv3z8/OVn5/v2M/Ozq6Q+gEAAIBbWZUJFgkJCdq3b5+2bNlyw342m02BgYF655135O7urk6dOunEiROaPn16scEiOTlZkydPrqiyAQAAAKiKTIUaNWqUVq5cqU2bNqlRo0Y37NugQQM1b95c7u7ujrZWrVopKytLly9fLtI/KSlJVqvVsR0/ftzp9QMAAAC3OpcGC7vdrlGjRmnp0qX65JNPFB4eftNjoqKidOjQIdlsNkfbd999pwYNGsjT07NIf7PZrICAgEIbAAAAAOdyabBISEjQvHnztGDBAvn7+ysrK0tZWVm6dOmSo09cXJySkpIc+yNHjtSPP/6op59+Wt99951WrVqladOmKSEhwRW3AAAAAEAuXmORkpIiSYqJiSnUPmfOHMXHx0uSMjMz5eb2v/wTEhKidevW6ZlnnlG7du0UHBysp59+Ws8//3xllQ0AAADgF0x2u93u6iIqU3Z2tiwWi6xWK9OiAAAAgBsoy3fnKrF4GwAAAED1RrAAAAAAYBjBAgAAAIBhBAsAAAAAhhEsAAAAABhGsAAAAABgGMECAAAAgGEECwAAAACGESwAAAAAGEawAAAAAGAYwQIAAACAYQQLAAAAAIYRLAAAAAAYRrAAAAAAYBjBAgAAAIBhBAsAAAAAhhEsAAAAABhGsAAAAABgGMECAAAAgGEECwAAAACGESwAAAAAGEawAAAAAGAYwQIAAACAYQQLAAAAAIYRLAAAAAAY5tJgkZycrMjISPn7+yswMFD9+/fXwYMHb3hMamqqTCZToc3Ly6uSKgYAAABQHJcGi82bNyshIUHbtm3Thg0bdOXKFfXs2VO5ubk3PC4gIECnTp1ybMeOHaukigEAAAAUx8OVF1+7dm2h/dTUVAUGBmr37t2Kjo4u8TiTyaT69etXdHkAAAAASqlKrbGwWq2SpNq1a9+w34ULFxQaGqqQkBD169dP+/fvr4zyAAAAAJSgygQLm82m0aNHKyoqShERESX2a9Gihd59910tX75c8+bNk81mU5cuXfSf//yn2P75+fnKzs4utAEAAABwLpPdbre7ughJGjlypNasWaMtW7aoUaNGpT7uypUratWqlQYNGqSpU6cW+XzSpEmaPHlykXar1aqAgABDNQMAAAC/ZtnZ2bJYLKX67lwlRixGjRqllStXatOmTWUKFZJUo0YNdejQQYcOHSr286SkJFmtVsd2/PhxZ5QMAAAA4GdcunjbbrcrMTFRS5cuVXp6usLDw8t8joKCAu3du1d9+/Yt9nOz2Syz2Wy0VAAAAAA34NJgkZCQoAULFmj58uXy9/dXVlaWJMliscjb21uSFBcXp+DgYCUnJ0uSpkyZorvvvltNmzbV+fPnNX36dB07dkyPPfaYy+4DAAAAuNW5NFikpKRIkmJiYgq1z5kzR/Hx8ZKkzMxMubn9b8bWTz/9pD/+8Y/KyspSrVq11KlTJ23dulWtW7eurLIBAAAA/EKVWbxdWcqyAAUAAAC4lVW7xdsAAAAAqjeCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMA9XFwAAgGwF0rGt0oXTkl+QFNpFcnN3dVUAgDIgWAAAXCtjhbT2eSn75P/aAhpKvV+WWt/nuroAAGXCVCgAgOtkrJA+iCscKiQp+9S19owVrqkLAFBmBAsAgGvYCq6NVMhezIf/bVv7wrV+AIAqj2ABAHCNY1uLjlQUYpeyT1zrBwCo8ggWAADXuHDauf0AAC5FsAAAuIZfkHP7AQBcimABAHCN0C7Xnv4kUwkdTFJA8LV+AIAqj2ABAHANN/drj5SVVDRc/He/90u8zwIAqgmXBovk5GRFRkbK399fgYGB6t+/vw4ePFjq49PS0mQymdS/f/+KKxIAUHFa3ycNfE8KaFC4PaDhtXbeYwEA1YZLX5C3efNmJSQkKDIyUlevXtXYsWPVs2dPZWRkyNfX94bHHj16VGPGjNE999xTSdUCACpE6/uklr/jzdsAUM2Z7HZ7cQ8Qd4mzZ88qMDBQmzdvVnR0dIn9CgoKFB0dreHDh+uzzz7T+fPntWzZslJdIzs7WxaLRVarVQEBAU6qHAAAAPj1Kct35yq1xsJqtUqSateufcN+U6ZMUWBgoEaMGHHTc+bn5ys7O7vQBgAAAMC5qkywsNlsGj16tKKiohQREVFivy1btmj27NmaNWtWqc6bnJwsi8Xi2EJCQpxVMgAAAID/qjLBIiEhQfv27VNaWlqJfXJycvToo49q1qxZqlu3bqnOm5SUJKvV6tiOHz/urJIBAAAA/JdLF29fN2rUKK1cuVKffvqpGjVqVGK/f//73zp69KhiY2MdbTabTZLk4eGhgwcPqkmTJoWOMZvNMpvNFVM4AAAAAEkuDhZ2u12JiYlaunSp0tPTFR4efsP+LVu21N69ewu1jRs3Tjk5OXr99deZ5gQAAAC4iEuDRUJCghYsWKDly5fL399fWVlZkiSLxSJvb29JUlxcnIKDg5WcnCwvL68i6y9q1qwpSTdclwEAAACgYrk0WKSkpEiSYmJiCrXPmTNH8fHxkqTMzEy5uVWZpSAAAAAAilGl3mNRGXiPBQAAAFA61fY9FgAAAACqJ4IFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMMzD1QVUNrvdLknKzs52cSUAAABA1Xb9O/P179A3cssFi5ycHElSSEiIiysBAAAAqoecnBxZLJYb9jHZSxM/fkVsNptOnjwpf39/mUwmV5cDAPiv7OxshYSE6Pjx4woICHB1OQAAXRupyMnJUcOGDeXmduNVFLdcsAAAVE3Z2dmyWCyyWq0ECwCohli8DQAAAMAwggUAAAAAwwgWAIAqwWw2a+LEiTKbza4uBQBQDqyxAAAAAGAYIxYAAAAADCNYAAAAADCMYAEAAADAMIIFAMDl/vnPfyosLExeXl666667tGPHDleXBAAoI4IFAMCl3n//fT377LOaOHGivvzyS7Vv3169evXSmTNnXF0aAKAMeCoUAMCl7rrrLkVGRurNN9+UJNlsNoWEhCgxMVEvvPCCi6sDAJQWIxYAAJe5fPmydu/erR49ejja3Nzc1KNHD33xxRcurAwAUFYECwCAy5w7d04FBQUKCgoq1B4UFKSsrCwXVQUAKA+CBQAAAADDCBYAAJepW7eu3N3ddfr06ULtp0+fVv369V1UFQCgPAgWAACX8fT0VKdOnbRx40ZHm81m08aNG9W5c2cXVgYAKCsPVxcAALi1Pfvssxo6dKjuuOMO3XnnnXrttdeUm5urYcOGubo0AEAZECwAAC718MMP6+zZs5owYYKysrJ0++23a+3atUUWdAMAqjbeYwEAAADAMNZYAAAAADCMYAEAAADAMIIFAAAAAMMIFgAAAAAMI1gAAAAAMIxgAQAAAMAwggUAAAAAwwgWAAAAAAwjWAAAqjWTyaRly5a5ugwAuOURLAAA5RYfHy+TyVRk6927t6tLAwBUMg9XFwAAqN569+6tOXPmFGozm80uqgYA4CqMWAAADDGbzapfv36hrVatWpKuTVNKSUlRnz595O3trcaNG2vx4sWFjt+7d6+6desmb29v1alTR48//rguXLhQqM+7776rNm3ayGw2q0GDBho1alShz8+dO6f7779fPj4+atasmVasWFGxNw0AKIJgAQCoUOPHj9eAAQP09ddfa/DgwXrkkUd04MABSVJubq569eqlWrVqaefOnVq0aJE+/vjjQsEhJSVFCQkJevzxx7V3716tWLFCTZs2LXSNyZMna+DAgfrmm2/Ut29fDR48WD/++GOl3icA3OpMdrvd7uoiAADVU3x8vObNmycvL69C7WPHjtXYsWNlMpn0xBNPKCUlxfHZ3XffrY4dO2rmzJmaNWuWnn/+eR0/fly+vr6SpNWrVys2NlYnT55UUFCQgoODNWzYMP3lL38ptgaTyaRx48Zp6tSpkq6FFT8/P61Zs4a1HgBQiVhjAQAw5Le//W2h4CBJtWvXdvzcuXPnQp917txZe/bskSQdOHBA7du3d4QKSYqKipLNZtPBgwdlMpl08uRJde/e/YY1tGvXzvGzr6+vAgICdObMmfLeEgCgHAgWAABDfH19i0xNchZvb+9S9atRo0ahfZPJJJvNVhElAQBKwBoLAECF2rZtW5H9Vq1aSZJatWqlr7/+Wrm5uY7PP//8c7m5ualFixby9/dXWFiYNm7cWKk1AwDKjhELAIAh+fn5ysrKKtTm4eGhunXrSpIWLVqkO+64Q7/5zW80f/587dixQ7Nnz5YkDR48WBMnTtTQoUM1adIknT17VomJiXr00UcVFBQkSZo0aZKeeOIJBQYGqk+fPsrJydHnn3+uxMTEyr1RAMANESwAAIasXbtWDRo0KNTWokULffvtt5KuPbEpLS1NTz75pBo0aKCFCxeqdevWkiQfHx+tW7dOTz/9tCIjI+Xj46MBAwZoxowZjnMNHTpUeXl5+vvf/64xY8aobt26evDBByvvBgEApcJToQAAFcZkMmnp0qXq37+/q0sBAFQw1lgAAAAAMIxgAQAAAMAw1lgAACoMs20B4NbBiAUAAAAAwwgWAAAAAAwjWAAAAAAwjGABAAAAwDCCBQAAAADDCBYAAAAADCNYAAAAADCMYAEAAADAMIIFAAAAAMP+P1eidL+PQXTjAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_training_history(history, metrics=[\"loss\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75ac3bd9-3bfd-413d-95fa-a3cfaceb6ac7",
+   "metadata": {},
+   "source": [
+    "## Save Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1bc2aea9-b047-476b-806b-5e0bc0a3a5ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.save(f\"../models/tmp/{dataset_name}_decoder_model.keras\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94d7898b-89be-40ce-b732-ab64fd8fb748",
+   "metadata": {},
+   "source": [
+    "## Save Split Datasets"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "425e9987-fd40-42e6-a0b2-362220eb9cd9",
+   "metadata": {},
+   "source": [
+    "tf.data.Dataset.save(test_ds, \"<save_path>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f876e47-71dd-4481-92c6-b4bac6c00b1d",
+   "metadata": {},
+   "source": [
+    "## Evaluate Model on Test Set"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2baccd28-d4fd-4b5a-b4a7-e237449caba7",
+   "metadata": {},
+   "source": [
+    "Note: This logic should probably be separated into a different notebook for model evaluation, where where the model, tokenizer, image_features, test_ds, etc. are loaded. It's here because it was convenient for debugging purposes with changes spanning multiple modules."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddd158f0-eb54-4b01-80d7-6c59f3c38304",
+   "metadata": {},
+   "source": [
+    "### This evaluates the entire test dataset"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "04980a46-40fb-43f5-b14d-9be02895af83",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "# Rebatch test dataset into larger or smaller batches, depending on your system memory\n",
+    "# larger batches for faster inference (as long as you have enough memory)\n",
+    "new_batch_size = 128\n",
+    "batched_test_ds_for_eval = test_ds.unbatch().batch(new_batch_size).prefetch(tf.data.AUTOTUNE)\n",
+    "\n",
+    "# Load captions into references dict\n",
+    "references_dict = load_and_clean_captions(f\"../data/raw/{dataset_name}_captions.csv\")\n",
+    "\n",
+    "scores = evaluate_model(\n",
+    "    model=model,\n",
+    "    tokenizer=tokenizer,\n",
+    "    features=features,\n",
+    "    test_dataset=test_ds,\n",
+    "    references_dict=references_dict,\n",
+    "    max_len=max_caption_len,\n",
+    ")\n",
+    "\n",
+    "print(\"Evaluation Scores:\")\n",
+    "for metric, score in scores.items():\n",
+    "    print(f\"{metric}: {score:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3c671c0-2f56-4eb5-8dd4-4b110c541420",
+   "metadata": {},
+   "source": [
+    "### This evaluates a small portion of the test dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c791a894-35d6-4674-a0b5-6d5289dee5d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Evaluating on a partial test set: 1 batches (approx. 32 samples)\n",
+      "Note: Dataset size is unknown. Progress bar will not show total batches.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Generating Captions from Dataset: 0it [00:00, ?it/s]2025-07-17 15:56:08.084448: W tensorflow/core/kernels/data/cache_dataset_ops.cc:916] The calling iterator did not fully read the dataset being cached. In order to avoid unexpected truncation of the dataset, the partially cached contents of the dataset  will be discarded. This can happen if you have an input pipeline similar to `dataset.cache().take(k).repeat()`. You should use `dataset.take(k).cache().repeat()` instead.\n",
+      "Generating Captions from Dataset: 1it [00:31, 31.28s/it]2025-07-17 15:56:39.317270: I tensorflow/core/framework/local_rendezvous.cc:407] Local rendezvous is aborting with status: OUT_OF_RANGE: End of sequence\n",
+      "Generating Captions from Dataset: 1it [00:31, 31.29s/it]\n",
+      "/home/curtis/anaconda3/envs/northeastern/lib/python3.10/site-packages/huggingface_hub/file_download.py:943: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
+      "  warnings.warn(\n",
+      "Some weights of RobertaModel were not initialized from the model checkpoint at roberta-large and are newly initialized: ['roberta.pooler.dense.bias', 'roberta.pooler.dense.weight']\n",
+      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evaluation Scores:\n",
+      "BLEU-1: 0.4295\n",
+      "BLEU-2: 0.2338\n",
+      "BLEU-3: 0.1195\n",
+      "BLEU-4: 0.0715\n",
+      "METEOR: 0.2799\n",
+      "BERTScore_P: 0.8568\n",
+      "BERTScore_R: 0.8492\n",
+      "BERTScore_F1: 0.8529\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Rebatch test dataset into larger or smaller batches, depending on your system memory\n",
+    "# larger batches for faster inference (as long as you have enough memory)\n",
+    "new_batch_size = 32\n",
+    "batched_test_ds_for_eval = test_ds.unbatch().batch(new_batch_size).prefetch(tf.data.AUTOTUNE)\n",
+    "\n",
+    "# Load captions into references dict\n",
+    "references_dict = load_and_clean_captions(f\"../data/raw/{dataset_name}_captions.csv\")\n",
+    "\n",
+    "# Evaluate only a portion of the test dataset\n",
+    "num_batches_to_evaluate = 1\n",
+    "partial_test_ds_for_eval = batched_test_ds_for_eval.take(num_batches_to_evaluate)\n",
+    "print(f\"\\nEvaluating on a partial test set: {num_batches_to_evaluate} batches\",\n",
+    "      f\"(approx. {num_batches_to_evaluate * new_batch_size} samples)\"\n",
+    ")\n",
+    "\n",
+    "scores = evaluate_model(\n",
+    "    model=model,\n",
+    "    tokenizer=tokenizer,\n",
+    "    features=features,\n",
+    "    test_dataset=partial_test_ds_for_eval,\n",
+    "    references_dict=references_dict,\n",
+    "    max_len=max_caption_len,\n",
+    ")\n",
+    "\n",
+    "print(\"Evaluation Scores:\")\n",
+    "for metric, score in scores.items():\n",
+    "    print(f\"{metric}: {score:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f405772b-86b6-4128-a100-fc4b08db2021",
+   "metadata": {},
+   "source": [
+    "## Predict Sample Captions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6887c71-d2aa-4008-9fc0-87544cc6d70d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_folder = f\"../../data/flickr8k_images/\"\n",
+    "sample_image_ids = [\n",
+    "    \"667626_18933d713e.jpg\",\n",
+    "    \"23445819_3a458716c1.jpg\",\n",
+    "    \"27782020_4dab210360.jpg\",\n",
+    "    \"35506150_cbdb630f4f.jpg\",\n",
+    "    \"47870024_73a4481f7d.jpg\"\n",
+    "]\n",
+    "\n",
+    "display_images_with_captions(\n",
+    "    image_ids=sample_image_ids,\n",
+    "    model=model,\n",
+    "    tokenizer=tokenizer,\n",
+    "    features=features,\n",
+    "    image_folder=image_folder\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acab7d98-631f-470e-8be7-71ca62e7d6bb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "northeastern",
+   "language": "python",
+   "name": "northeastern"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# pyproject.toml
+
 [project]
 name = "vtt"
 version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,37 @@ build-backend = "setuptools.build_meta"
 # Find packages within the 'src' directory
 [tool.setuptools.packages.find]
 where = ["src"] # Look for packages in the 'src' directory
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | build
+  | dist
+  | __pycache__
+  | notebooks
+  | data
+  | .*\.ipynb
+)/
+'''
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = [
+    "E203",  # whitespace before ':', handled by black
+    "W503",  # line break before binary operator, handled by black
+]
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+    ".venv",
+    "notebooks",
+    "data",
+    "*.ipynb"
+]

--- a/scripts/model_runnner.py
+++ b/scripts/model_runnner.py
@@ -15,7 +15,7 @@ os.makedirs(output_dir, exist_ok=True)
 df = pd.read_csv(caption_path)
 
 # Group captions by image
-image_caption_map = df.groupby('image')['caption'].apply(list).to_dict()
+image_caption_map = df.groupby("image")["caption"].apply(list).to_dict()
 
 # Shuffle and split
 image_list = list(image_caption_map.keys())
@@ -26,10 +26,10 @@ train_images = image_list[:split_idx]
 val_images = image_list[split_idx:]
 
 # Save splits
-with open(train_file, 'w') as f:
-    f.write('\n'.join(train_images))
+with open(train_file, "w") as f:
+    f.write("\n".join(train_images))
 
-with open(val_file, 'w') as f:
-    f.write('\n'.join(val_images))
+with open(val_file, "w") as f:
+    f.write("\n".join(val_images))
 
 print(f"✅ CSV Split complete: {len(train_images)} train, {len(val_images)} val")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,17 +1,18 @@
 # __init__.py
 
-__version__ = "0.1.0" # Or whatever your current version is
+__version__ = "0.1.0"  # Or whatever your current version is
 
 # Make key components directly accessible
 
 
 # Define what 'from vtt import *' would expose
-__all__ = [
-    "__version__"
-]
+__all__ = ["__version__"]
 
 # Basic logging setup if desired
 import logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 logger.info("Vision-to-Text package initialized.")

--- a/src/vtt/data/caption_preprocessing.py
+++ b/src/vtt/data/caption_preprocessing.py
@@ -10,6 +10,7 @@ padding, and saving/loading captions in various formats.
 import os
 import pickle
 import re
+import json
 from collections import Counter, defaultdict
 from typing import Dict, List, Set, Tuple
 
@@ -277,3 +278,44 @@ def load_tokenizer(filepath: str) -> Tokenizer:
         return tokenizer
     else:
         raise ValueError("Unsupported file format. Use .pkl or .json")
+
+
+def build_raw_captions_dict_from_csv(captions_csv_path: str) -> Dict[str, List[str]]:
+    """
+    Reads a CSV file and builds a dictionary mapping image IDs to lists of captions.
+
+    Args:
+        captions_csv_path (str): Path to the CSV file with columns [image_id, caption].
+
+    Returns:
+        Dict[str, List[str]]: A dictionary mapping image_id to a list of its captions.
+    """
+    captions_dict = defaultdict(list)
+
+    with open(captions_csv_path, mode="r", encoding="utf-8") as csvfile:
+        reader = csv.reader(csvfile)
+        header = next(reader)  # Skip header
+        for row in reader:
+            if len(row) != 2:
+                continue  # Skip malformed rows
+            image_id, caption = row
+            captions_dict[image_id].append(caption.strip())
+
+    return dict(captions_dict)
+
+
+def load_captions_dict(captions_path: str) -> Dict[str, List[str]]:
+    """
+    Loads a JSON file of cleaned captions and returns a dictionary
+    mapping image_id to a list of reference captions.
+
+    Args:
+        captions_path (str): Path to the JSON file containing captions.
+
+    Returns:
+        Dict[str, List[str]]: Dictionary of image_id -> list of captions.
+    """
+    with open(captions_path, "r") as f:
+        captions_data = json.load(f)
+
+    return captions_data

--- a/src/vtt/data/caption_preprocessing.py
+++ b/src/vtt/data/caption_preprocessing.py
@@ -8,15 +8,16 @@ padding, and saving/loading captions in various formats.
 """
 
 import os
-import re
-from typing import Dict, List, Set, Tuple
-from collections import defaultdict, Counter
-import numpy as np
-from tensorflow.keras.preprocessing.text import Tokenizer, tokenizer_from_json
-from tensorflow.keras.preprocessing.sequence import pad_sequences
 import pickle
-import json
-from vtt.utils.config import START_TOKEN, END_TOKEN, OOV_TOKEN
+import re
+from collections import Counter, defaultdict
+from typing import Dict, List, Set, Tuple
+
+import numpy as np
+from tensorflow.keras.preprocessing.sequence import pad_sequences
+from tensorflow.keras.preprocessing.text import Tokenizer, tokenizer_from_json
+
+from vtt.utils.config import END_TOKEN, OOV_TOKEN, START_TOKEN
 
 
 def clean_caption(text: str) -> str:

--- a/src/vtt/data/data_loader.py
+++ b/src/vtt/data/data_loader.py
@@ -94,6 +94,13 @@ def load_split_datasets(
     test_size = int(test_split * total)
     train_size = total - val_size - test_size
 
+    print("\n--- Dataset Split Sizes (number of individual samples) ---")
+    print(f"Total samples loaded: {total}")
+    print(f"Train samples: {train_size}")
+    print(f"Validation samples: {val_size}")
+    print(f"Test samples: {test_size}")
+    print("----------------------------------------------------------\n")
+
     train_X, train_y, train_ids = (
         image_features[:train_size],
         caption_sequences[:train_size],

--- a/src/vtt/data/data_loader.py
+++ b/src/vtt/data/data_loader.py
@@ -1,115 +1,52 @@
-"""
-data_loader.py
-
-This module provides utilities for loading and preparing image-caption datasets
-as TensorFlow `tf.data.Dataset` objects suitable for training, validation, and testing.
-
-It handles loading features and caption sequences from `.npz` files, aligning features
-with captions based on image IDs, splitting into train/validation/test, preparing the
-data for sequence-to-sequence learning, and setting up batching and shuffling for
-efficient data pipeline processing.
-"""
-
-from typing import Optional, Tuple, Union
-
 import numpy as np
 import tensorflow as tf
+from typing import Tuple, Optional, Union, List
 
 
 def load_features_and_sequences(
     features_path: str, captions_path: str
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, List[str]]:
     """
-    Load aligned image features and caption sequences from .npz files.
-
-    Args:
-        features_path (str): Path to the .npz file of image features
-            {image_id: feature_vector}.
-        captions_path (str): Path to the .npz file of padded caption sequences
-                             {image_id: [sequence1, sequence2, ...]}.
+    Load aligned image features and caption sequences from .npz files,
+    along with associated image IDs for each (feature, caption) pair.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: Two NumPy arrays (features, captions),
-            aligned 1:1.
+        Tuple[np.ndarray, np.ndarray, List[str]]: Features, captions, image IDs
     """
     features_npz = np.load(features_path)
     captions_npz = np.load(captions_path, allow_pickle=True)
 
     image_features = []
     caption_sequences = []
+    image_ids = []
 
     for img_id in captions_npz.files:
         if img_id in features_npz:
             for caption in captions_npz[img_id]:
                 image_features.append(features_npz[img_id])
                 caption_sequences.append(caption)
+                image_ids.append(img_id)
 
     return (
         np.asarray(image_features, dtype=np.float32),
         np.asarray(caption_sequences, dtype=np.int32),
+        image_ids,
     )
 
 
 def prepare_dataset(dataset: tf.data.Dataset) -> tf.data.Dataset:
     """
-    Split each caption into (input, target) for sequence-to-sequence training.
+    Split each caption into (input, target) for seq2seq training,
+    while preserving image IDs.
 
-    Args:
-        dataset (tf.data.Dataset): A dataset of (image_feature, full_caption) pairs.
-
-    Returns:
-        tf.data.Dataset: A dataset of ((image_feature, input_caption), target_caption)
-            pairs.
+    Input dataset should yield (image, caption, image_id).
+    Output yields ((image, caption_input, image_id), caption_target).
     """
 
-    def split_inputs_and_targets(img, caption):
-        return (img, caption[:-1]), caption[1:]
+    def split_inputs_and_targets(img, caption, img_id):
+        return ((img, caption[:-1], img_id), caption[1:])
 
     return dataset.map(split_inputs_and_targets, num_parallel_calls=tf.data.AUTOTUNE)
-
-
-def load_training_dataset(
-    features_path: str,
-    captions_path: str,
-    batch_size: int = 32,
-    shuffle: bool = True,
-    buffer_size: int = 1000,
-    cache: bool = False,
-) -> tf.data.Dataset:
-    """
-    Loads and returns a fully-prepared tf.data.Dataset ready for training.
-    It handles loading, aligning, splitting, batching, and prefetching.
-
-    Args:
-        features_path (str): Path to image features .npz file.
-        captions_path (str): Path to padded caption sequences .npz file.
-        batch_size (int): Batch size for training.
-        shuffle (bool): Whether to shuffle the dataset before training.
-        buffer_size (int): Buffer size for shuffling.
-        cache (bool): Whether to cache the dataset in memory. Defaults to False.
-
-    Returns:
-        tf.data.Dataset: Batches of ((image, caption_input), caption_target)
-    """
-    # Load raw aligned feature-caption pairs
-    image_features, caption_sequences = load_features_and_sequences(
-        features_path, captions_path
-    )
-    assert len(image_features) == len(
-        caption_sequences
-    ), "Mismatched features and captions."
-
-    # Split into inputs and targets
-    dataset = tf.data.Dataset.from_tensor_slices((image_features, caption_sequences))
-    dataset = prepare_dataset(dataset)
-
-    if cache:
-        dataset = dataset.cache()
-    if shuffle:
-        dataset = dataset.shuffle(buffer_size)
-
-    # Apply batching and prefetching in correct order
-    return dataset.batch(batch_size, drop_remainder=True).prefetch(tf.data.AUTOTUNE)
 
 
 def load_split_datasets(
@@ -125,96 +62,84 @@ def load_split_datasets(
     return_numpy: bool = False,
 ) -> Union[
     Tuple[tf.data.Dataset, tf.data.Dataset, tf.data.Dataset],
-    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
+    Tuple[
+        np.ndarray,
+        np.ndarray,
+        List[str],
+        np.ndarray,
+        np.ndarray,
+        List[str],
+        np.ndarray,
+        np.ndarray,
+        List[str],
+    ],
 ]:
     """
-    Load features and captions, perform a train/val/test split, and return preprocessed
-    tf.data.Datasets or optionally the raw NumPy arrays.
-
-    Args:
-        features_path (str): Path to the .npz file with image features.
-        captions_path (str): Path to the .npz file with padded caption sequences.
-        batch_size (int): Number of samples per batch. Defaults to 32.
-        val_split (float): Proportion of data to use for validation. Defaults 0.15.
-        test_split (float): Proportion of data to use for testing. Defaults to 0.10.
-        shuffle (bool): Whether to shuffle the data before splitting. Defaults to True
-        buffer_size (int): Buffer size for shuffling. Defaults to 1000.
-        seed (int, optional): Random seed for shuffling. Defaults to 42.
-        cache (bool): Whether to cache the dataset in memory. Defaults to False.
-        return_numpy (bool): If True, return NumPy arrays instead of tf.data.Dataset
-            objects. Defaults to False.
-
-    Returns:
-        If return_numpy is False:
-            Tuple[tf.data.Dataset, tf.data.Dataset, tf.data.Dataset]
-        If return_numpy is True:
-            Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]  # noqa: E501
-            (train_X, train_y, val_X, val_y, test_X, test_y)
+    Load and split dataset into train/val/test, preserving image IDs for evaluation.
     """
-    image_features, caption_sequences = load_features_and_sequences(
+    image_features, caption_sequences, image_ids = load_features_and_sequences(
         features_path, captions_path
     )
-    assert len(image_features) == len(
-        caption_sequences
-    ), "Mismatched features and captions."
+    assert len(image_features) == len(caption_sequences) == len(image_ids)
 
-    # Shuffle before splitting
     if shuffle:
         rng = np.random.default_rng(seed)
         idx = rng.permutation(len(image_features))
         image_features = image_features[idx]
         caption_sequences = caption_sequences[idx]
+        image_ids = [image_ids[i] for i in idx]
 
-    # Compute split boundaries
     total = len(image_features)
     val_size = int(val_split * total)
     test_size = int(test_split * total)
     train_size = total - val_size - test_size
 
-    # Split datasets
-    train_X = image_features[:train_size]
-    train_y = caption_sequences[:train_size]
-    val_X = image_features[train_size : train_size + val_size]
-    val_y = caption_sequences[train_size : train_size + val_size]
-    test_X = image_features[train_size + val_size :]
-    test_y = caption_sequences[train_size + val_size :]
+    train_X, train_y, train_ids = (
+        image_features[:train_size],
+        caption_sequences[:train_size],
+        image_ids[:train_size],
+    )
+    val_X, val_y, val_ids = (
+        image_features[train_size : train_size + val_size],
+        caption_sequences[train_size : train_size + val_size],
+        image_ids[train_size : train_size + val_size],
+    )
+    test_X, test_y, test_ids = (
+        image_features[train_size + val_size :],
+        caption_sequences[train_size + val_size :],
+        image_ids[train_size + val_size :],
+    )
 
     if return_numpy:
-        return train_X, train_y, val_X, val_y, test_X, test_y
+        return (
+            train_X,
+            train_y,
+            train_ids,
+            val_X,
+            val_y,
+            val_ids,
+            test_X,
+            test_y,
+            test_ids,
+        )
 
     def make_dataset(
-        features: np.ndarray, captions: np.ndarray, drop_remainder: bool
+        features: np.ndarray, captions: np.ndarray, ids: List[str], drop_remainder: bool
     ) -> tf.data.Dataset:
-        """
-        Create a tf.data.Dataset pipeline from NumPy arrays, optionally caching,
-        shuffling, batching, and prefetching the data.
-
-        Args:
-            features (np.ndarray): Image feature vectors.
-            captions (np.ndarray): Corresponding padded caption sequences.
-            drop_remainder (bool): Whether to drop the last batch if it is smaller than
-                `batch_size`.
-
-        Returns:
-            tf.data.Dataset: A batched, prefetched dataset suitable for training or
-                evaluation.
-        """
-        dataset = tf.data.Dataset.from_tensor_slices((features, captions))
-        dataset = prepare_dataset(dataset)
+        ds = tf.data.Dataset.from_tensor_slices((features, captions, ids))
+        ds = prepare_dataset(ds)
 
         if cache:
-            dataset = dataset.cache()
+            ds = ds.cache()
         if shuffle:
-            dataset = dataset.shuffle(buffer_size)
+            ds = ds.shuffle(buffer_size)
 
-        return dataset.batch(batch_size, drop_remainder=drop_remainder).prefetch(
+        return ds.batch(batch_size, drop_remainder=drop_remainder).prefetch(
             tf.data.AUTOTUNE
         )
 
     return (
-        make_dataset(
-            train_X, train_y, True
-        ),  # drop_remainder = True for training to ensure consistent batch shape
-        make_dataset(val_X, val_y, False),  # keep all data for validation
-        make_dataset(test_X, test_y, False),  # keep all data for testing
+        make_dataset(train_X, train_y, train_ids, True),
+        make_dataset(val_X, val_y, val_ids, False),
+        make_dataset(test_X, test_y, test_ids, False),
     )

--- a/src/vtt/data/data_loader.py
+++ b/src/vtt/data/data_loader.py
@@ -10,9 +10,10 @@ data for sequence-to-sequence learning, and setting up batching and shuffling fo
 efficient data pipeline processing.
 """
 
+from typing import Optional, Tuple, Union
+
 import numpy as np
 import tensorflow as tf
-from typing import Tuple, Optional, Union
 
 
 def load_features_and_sequences(
@@ -22,12 +23,14 @@ def load_features_and_sequences(
     Load aligned image features and caption sequences from .npz files.
 
     Args:
-        features_path (str): Path to the .npz file of image features {image_id: feature_vector}.
+        features_path (str): Path to the .npz file of image features
+            {image_id: feature_vector}.
         captions_path (str): Path to the .npz file of padded caption sequences
                              {image_id: [sequence1, sequence2, ...]}.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: Two NumPy arrays (features, captions), aligned 1:1.
+        Tuple[np.ndarray, np.ndarray]: Two NumPy arrays (features, captions),
+            aligned 1:1.
     """
     features_npz = np.load(features_path)
     captions_npz = np.load(captions_path, allow_pickle=True)
@@ -55,7 +58,8 @@ def prepare_dataset(dataset: tf.data.Dataset) -> tf.data.Dataset:
         dataset (tf.data.Dataset): A dataset of (image_feature, full_caption) pairs.
 
     Returns:
-        tf.data.Dataset: A dataset of ((image_feature, input_caption), target_caption) pairs.
+        tf.data.Dataset: A dataset of ((image_feature, input_caption), target_caption)
+            pairs.
     """
 
     def split_inputs_and_targets(img, caption):
@@ -124,8 +128,8 @@ def load_split_datasets(
     Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray],
 ]:
     """
-    Load features and captions, perform a train/val/test split, and return preprocessed tf.data.Datasets
-    or optionally the raw NumPy arrays.
+    Load features and captions, perform a train/val/test split, and return preprocessed
+    tf.data.Datasets or optionally the raw NumPy arrays.
 
     Args:
         features_path (str): Path to the .npz file with image features.
@@ -137,13 +141,14 @@ def load_split_datasets(
         buffer_size (int): Buffer size for shuffling. Defaults to 1000.
         seed (int, optional): Random seed for shuffling. Defaults to 42.
         cache (bool): Whether to cache the dataset in memory. Defaults to False.
-        return_numpy (bool): If True, return NumPy arrays instead of tf.data.Dataset objects. Defaults to False.
+        return_numpy (bool): If True, return NumPy arrays instead of tf.data.Dataset
+            objects. Defaults to False.
 
     Returns:
         If return_numpy is False:
             Tuple[tf.data.Dataset, tf.data.Dataset, tf.data.Dataset]
         If return_numpy is True:
-            Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+            Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]  # noqa: E501
             (train_X, train_y, val_X, val_y, test_X, test_y)
     """
     image_features, caption_sequences = load_features_and_sequences(
@@ -187,10 +192,12 @@ def load_split_datasets(
         Args:
             features (np.ndarray): Image feature vectors.
             captions (np.ndarray): Corresponding padded caption sequences.
-            drop_remainder (bool): Whether to drop the last batch if it is smaller than `batch_size`.
+            drop_remainder (bool): Whether to drop the last batch if it is smaller than
+                `batch_size`.
 
         Returns:
-            tf.data.Dataset: A batched, prefetched dataset suitable for training or evaluation.
+            tf.data.Dataset: A batched, prefetched dataset suitable for training or
+                evaluation.
         """
         dataset = tf.data.Dataset.from_tensor_slices((features, captions))
         dataset = prepare_dataset(dataset)
@@ -207,7 +214,7 @@ def load_split_datasets(
     return (
         make_dataset(
             train_X, train_y, True
-        ),  # drop_remainder = True for training; needed to ensure consistent batch shape
+        ),  # drop_remainder = True for training to ensure consistent batch shape
         make_dataset(val_X, val_y, False),  # keep all data for validation
         make_dataset(test_X, test_y, False),  # keep all data for testing
     )

--- a/src/vtt/data/image_preprocessing.py
+++ b/src/vtt/data/image_preprocessing.py
@@ -7,11 +7,13 @@ for saving and loading these extracted features to/from compressed NumPy `.npz` 
 """
 
 import os
+
 import numpy as np
-from tqdm import tqdm
 from tensorflow.keras.applications.resnet50 import ResNet50
 from tensorflow.keras.models import Model
 from tensorflow.keras.preprocessing import image
+from tqdm import tqdm
+
 from vtt.utils.config import IMAGE_SIZE, IMAGENET_MEAN, IMAGENET_STD
 
 
@@ -144,7 +146,8 @@ def extract_features_in_batches(
             continue
 
         tqdm.write(
-            f"[INFO] Processing batch {batch_idx + 1} of {total_batches} ({len(batch_image_names)} images)"
+            f"[INFO] Processing batch {batch_idx + 1} of ",
+            "{total_batches} ({len(batch_image_names)} images)",
         )
 
         batch_features = extract_features_from_filenames(image_dir, batch_image_names)

--- a/src/vtt/evaluation/evaluate.py
+++ b/src/vtt/evaluation/evaluate.py
@@ -20,10 +20,11 @@ Returns:
 """
 
 from typing import Dict, List
+
 from vtt.evaluation.metrics import (
+    compute_bertscore,
     compute_bleu_scores,
     compute_meteor_scores,
-    compute_bertscore,
 )
 
 
@@ -31,10 +32,12 @@ def evaluate_captions(
     references_dict: Dict[str, List[str]], predictions_dict: Dict[str, str]
 ) -> Dict[str, float]:
     """
-    Evaluate generated captions against reference captions using BLEU, METEOR, and BERTScore.
+    Evaluate generated captions against reference captions using BLEU, METEOR, and
+    BERTScore.
 
     Args:
-        references_dict (Dict[str, List[str]]): Mapping from image ID to a list of reference captions.
+        references_dict (Dict[str, List[str]]): Mapping from image ID to a list of
+            reference captions.
         predictions_dict (Dict[str, str]): Mapping from image ID to generated caption.
 
     Returns:

--- a/src/vtt/evaluation/metrics.py
+++ b/src/vtt/evaluation/metrics.py
@@ -18,12 +18,13 @@ Dependencies:
 - bert-score
 """
 
-import nltk
-from nltk.translate.bleu_score import sentence_bleu, SmoothingFunction
-from nltk.translate.meteor_score import meteor_score
-from typing import List, Dict
+from typing import Dict, List
+
 import bert_score
+import nltk
 import numpy as np
+from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
+from nltk.translate.meteor_score import meteor_score
 
 
 def ensure_nltk_resources():

--- a/src/vtt/models/decoder.py
+++ b/src/vtt/models/decoder.py
@@ -1,7 +1,9 @@
 """
 decoder.py
 
-This module defines the architecture for the decoder component of an image captioning system.
+This module defines the architecture for the decoder component of an image captioning
+system.
+
 The decoder receives:
     - A precomputed image embedding (e.g., from ResNet-50)
     - A sequence of tokenized caption inputs
@@ -20,8 +22,8 @@ Typical use:
 """
 
 import tensorflow as tf
+from tensorflow.keras.layers import LSTM, Concatenate, Dense, Embedding, Input, Lambda
 from tensorflow.keras.models import Model
-from tensorflow.keras.layers import Input, Dense, Embedding, LSTM, Concatenate, Lambda
 
 
 def build_decoder_model(
@@ -66,7 +68,8 @@ def build_decoder_model(
     )(caption_input)
 
     # ----- Merge Inputs -----
-    # Concatenate along time axis: output shape (batch_size, max_caption_len+1, embedding_dim)
+    # Concatenate along time axis:
+    # output shape (batch_size, max_caption_len+1, embedding_dim)
     merged = Concatenate(axis=1, name="merge_image_caption")([img_emb, caption_emb])
 
     # ----- Sequence Modeling -----
@@ -84,7 +87,9 @@ def build_decoder_model(
 
     # ----- Compile Model -----
     model = Model(
-        inputs=[img_input, caption_input], outputs=output, name="ImageCaptionDecoder"
+        inputs=[img_input, caption_input],
+        outputs=output,
+        name="ImageCaptionDecoder",
     )
     model.compile(loss="sparse_categorical_crossentropy", optimizer="adam")
 

--- a/src/vtt/models/predict.py
+++ b/src/vtt/models/predict.py
@@ -26,7 +26,7 @@ def generate_caption_greedy(
     model: Model,
     tokenizer: Tokenizer,
     image_feature: np.ndarray,
-    max_len: Optional[int] = None
+    max_len: Optional[int] = None,
 ) -> str:
     """
     Generates a caption from image features using greedy decoding.
@@ -59,7 +59,9 @@ def generate_caption_greedy(
         padded_seq = pad_sequences([caption_seq], maxlen=max_len, padding="post")
 
         # Predict next word using current sequence
-        preds = model.predict([np.expand_dims(image_feature, axis=0), padded_seq], verbose=0)
+        preds = model.predict(
+            [np.expand_dims(image_feature, axis=0), padded_seq], verbose=0
+        )
 
         # Take most probable word ID at the current time step
         next_id = int(np.argmax(preds[0, len(caption_seq) - 1, :]))
@@ -81,7 +83,7 @@ def display_images_with_captions(
     model: Model,
     tokenizer: Tokenizer,
     features: Dict[str, np.ndarray],
-    image_folder: str
+    image_folder: str,
 ) -> None:
     """
     Displays each image with its predicted caption.

--- a/src/vtt/models/predict.py
+++ b/src/vtt/models/predict.py
@@ -5,18 +5,21 @@ This module provides functions for generating image captions using a trained
 image captioning model and displaying the results alongside their corresponding images.
 
 Key functionality includes:
-- Greedy decoding: Generate captions one token at a time by selecting the most probable word.
+- Greedy decoding: Generate captions one token at a time by selecting the most probable
+  word.
 - Visualization: Display images with predicted captions using matplotlib.
 
 Usage example:
     caption = generate_caption_greedy(model, tokenizer, features["image123.jpg"])
-    display_images_with_captions(["image123.jpg"], model, tokenizer, features, "data/flickr8k_images_dataset/Images")
+    display_images_with_captions(["image123.jpg"], model, tokenizer, features,
+        "data/flickr8k_images_dataset/Images")
 """
 
-import numpy as np
+from typing import Dict, List, Optional
+
 import matplotlib.pyplot as plt
+import numpy as np
 from PIL import Image
-from typing import List, Dict, Optional
 from tensorflow.keras.models import Model
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 from tensorflow.keras.preprocessing.text import Tokenizer
@@ -35,7 +38,8 @@ def generate_caption_greedy(
         model (Model): Trained image captioning model.
         tokenizer (Tokenizer): Tokenizer used to encode/decode tokens.
         image_feature (np.ndarray): Precomputed image feature vector (shape: (2048,)).
-        max_len (Optional[int]): Maximum caption length. If None, inferred from model input.
+        max_len (Optional[int]): Maximum caption length. If None, inferred from model
+        input.
 
     Returns:
         str: Generated caption (excluding <startseq> and <endseq> tokens).
@@ -92,7 +96,8 @@ def display_images_with_captions(
         image_ids (List[str]): List of image filenames to visualize.
         model (Model): Trained captioning model.
         tokenizer (Tokenizer): Tokenizer used for caption generation.
-        features (Dict[str, np.ndarray]): Dictionary of precomputed image features keyed by image ID.
+        features (Dict[str, np.ndarray]): Dictionary of precomputed image features
+            keyed by image ID.
         image_folder (str): Path to the folder containing the original images.
     """
     for image_id in image_ids:

--- a/src/vtt/models/train.py
+++ b/src/vtt/models/train.py
@@ -25,14 +25,14 @@ def train_model(
     epochs: int = 10,
     checkpoint_path: str = "model_checkpoint.weights.h5",
     early_stop_patience: Optional[int] = 5,
-    val_dataset: Optional[tf.data.Dataset] = None
+    val_dataset: Optional[tf.data.Dataset] = None,
 ) -> tf.keras.callbacks.History:
     """
     Trains the image captioning model using the provided dataset.
 
-    This function takes a preprocessed and batched dataset, builds the model 
-    by forcing a dummy forward pass (to avoid tracing errors related to variable 
-    creation in tf.function), and fits the model with optional early stopping 
+    This function takes a preprocessed and batched dataset, builds the model
+    by forcing a dummy forward pass (to avoid tracing errors related to variable
+    creation in tf.function), and fits the model with optional early stopping
     and model checkpointing.
 
     Args:
@@ -50,7 +50,7 @@ def train_model(
     """
     # Force model to build before tracing starts ----
     # This avoids runtime errors caused by variable creation during model.fit()
-    for (dummy_inputs, _) in dataset.take(1):
+    for dummy_inputs, _ in dataset.take(1):
         dummy_img, dummy_caption = dummy_inputs
         _ = model((dummy_img, dummy_caption), training=False)
         break  # Only need one batch
@@ -63,24 +63,23 @@ def train_model(
             save_best_only=True,
             monitor="val_loss" if val_dataset else "loss",
             mode="min",
-            verbose=1
+            verbose=1,
         )
     ]
     # Add early stopping callback if applicable
     if early_stop_patience is not None:
-        callbacks.append(tf.keras.callbacks.EarlyStopping(
-            monitor="val_loss" if val_dataset else "loss",
-            patience=early_stop_patience,
-            restore_best_weights=True,
-            verbose=1
-        ))
+        callbacks.append(
+            tf.keras.callbacks.EarlyStopping(
+                monitor="val_loss" if val_dataset else "loss",
+                patience=early_stop_patience,
+                restore_best_weights=True,
+                verbose=1,
+            )
+        )
 
     # Train model
     history = model.fit(
-        dataset,
-        validation_data=val_dataset,
-        epochs=epochs,
-        callbacks=callbacks
+        dataset, validation_data=val_dataset, epochs=epochs, callbacks=callbacks
     )
 
     return history

--- a/src/vtt/models/train.py
+++ b/src/vtt/models/train.py
@@ -3,20 +3,20 @@ train.py
 
 This module defines the training routine for the image captioning decoder model.
 
-It supports:
-- Training with TensorFlow's `tf.data.Dataset`
-- Saving checkpoints of the best model based on training loss
-- Early stopping to avoid overfitting or wasted computation
+Features:
+- Trains using a TensorFlow `tf.data.Dataset`
+- Supports early stopping based on validation loss
+- Saves best model weights during training
 
 Typical usage:
-    history = train_model(dataset, model, epochs=20, checkpoint_path="models/decoder.ckpt")
+    history = train_model(
+        dataset, model, epochs=20, checkpoint_path="models/decoder.ckpt"
+    )
 """
 
-import os
 from typing import Optional
+
 import tensorflow as tf
-from tensorflow.keras.models import Model
-from tensorflow.keras.callbacks import ModelCheckpoint, EarlyStopping
 
 
 def train_model(
@@ -30,56 +30,57 @@ def train_model(
     """
     Trains the image captioning model using the provided dataset.
 
-    This function takes a preprocessed and batched dataset, builds the model
-    by forcing a dummy forward pass (to avoid tracing errors related to variable
-    creation in tf.function), and fits the model with optional early stopping
-    and model checkpointing.
+    This function forces a dummy forward pass to build the model before training,
+    then fits the model using optional early stopping and checkpointing.
 
     Args:
-        dataset (tf.data.Dataset): A TensorFlow dataset yielding
-            ((image_features_tensor, input_caption_tensor), target_caption_tensor)
-            for sequence-to-sequence training.
+        dataset (tf.data.Dataset): Training data yielding
+            ((image_features, input_caption), target_caption) tuples.
         model (tf.keras.Model): A compiled Keras model (e.g., ImageCaptionDecoder).
-        epochs (int): Number of training epochs to run. Defaults to 10.
-        checkpoint_path (str): Path to save model weights during training.
-        early_stop_patience (int, optional): Number of epochs to wait for improvement
-            in loss before stopping early. Set to None to disable early stopping.
+        epochs (int): Number of epochs to train. Defaults to 10.
+        checkpoint_path (str): Path to save the best model weights.
+        early_stop_patience (Optional[int]): Number of epochs with no improvement
+            before early stopping. Set to None to disable.
+        val_dataset (Optional[tf.data.Dataset]): Validation data for monitoring.
 
     Returns:
-        tf.keras.callbacks.History: A Keras History object containing training metrics.
+        tf.keras.callbacks.History: Keras training history object.
     """
-    # Force model to build before tracing starts ----
-    # This avoids runtime errors caused by variable creation during model.fit()
+    # Build model by calling it once with dummy input
     for dummy_inputs, _ in dataset.take(1):
         dummy_img, dummy_caption = dummy_inputs
-        _ = model((dummy_img, dummy_caption), training=False)
-        break  # Only need one batch
+        model((dummy_img, dummy_caption), training=False)
+        break
 
-    # Set up callbacks
+    # Setup callbacks
+    monitor_metric = "val_loss" if val_dataset else "loss"
     callbacks = [
         tf.keras.callbacks.ModelCheckpoint(
             filepath=checkpoint_path,
             save_weights_only=True,
             save_best_only=True,
-            monitor="val_loss" if val_dataset else "loss",
+            monitor=monitor_metric,
             mode="min",
             verbose=1,
         )
     ]
-    # Add early stopping callback if applicable
+
     if early_stop_patience is not None:
         callbacks.append(
             tf.keras.callbacks.EarlyStopping(
-                monitor="val_loss" if val_dataset else "loss",
+                monitor=monitor_metric,
                 patience=early_stop_patience,
                 restore_best_weights=True,
                 verbose=1,
             )
         )
 
-    # Train model
+    # Train the model
     history = model.fit(
-        dataset, validation_data=val_dataset, epochs=epochs, callbacks=callbacks
+        dataset,
+        validation_data=val_dataset,
+        epochs=epochs,
+        callbacks=callbacks,
     )
 
     return history

--- a/src/vtt/utils/config.py
+++ b/src/vtt/utils/config.py
@@ -3,7 +3,7 @@ config.py
 
 Global configuration constants used across the project.
 
-This module centralizes parameters and special tokens to ensure consistency 
+This module centralizes parameters and special tokens to ensure consistency
 across different components including preprocessing, tokenization, and model input.
 
 Constants:

--- a/src/vtt/utils/helpers.py
+++ b/src/vtt/utils/helpers.py
@@ -34,7 +34,7 @@ def detect_and_set_device() -> str:
     # Check whether TensorFlow was compiled with GPU support
     if tf.test.is_built_with_cuda():
         # List available GPU devices
-        physical_devices = tf.config.list_physical_devices('GPU')
+        physical_devices = tf.config.list_physical_devices("GPU")
 
         if physical_devices:
             print("GPU is available. Attempting to use GPU.")
@@ -43,17 +43,20 @@ def detect_and_set_device() -> str:
                 for gpu in physical_devices:
                     tf.config.experimental.set_memory_growth(gpu, True)
                 print(f"Successfully configured GPU(s): {physical_devices}")
-                return 'GPU'
+                return "GPU"
             except RuntimeError as e:
                 # RuntimeError can occur if memory growth is set after device initialization
                 print(f"Error setting GPU memory growth: {e}. Falling back to CPU.")
-                return 'CPU'
+                return "CPU"
         else:
-            print("No GPU devices found despite TensorFlow being built with CUDA. Using CPU.")
-            return 'CPU'
+            print(
+                "No GPU devices found despite TensorFlow being built with CUDA. Using CPU."
+            )
+            return "CPU"
     else:
         print("TensorFlow is not built with CUDA support. Using CPU.")
-        return 'CPU'
+        return "CPU"
+
 
 def set_seed(seed: int = 42) -> None:
     """

--- a/src/vtt/utils/helpers.py
+++ b/src/vtt/utils/helpers.py
@@ -14,6 +14,7 @@ Functionality:
 
 import os
 import random
+
 import numpy as np
 import tensorflow as tf
 
@@ -45,12 +46,14 @@ def detect_and_set_device() -> str:
                 print(f"Successfully configured GPU(s): {physical_devices}")
                 return "GPU"
             except RuntimeError as e:
-                # RuntimeError can occur if memory growth is set after device initialization
+                # RuntimeError can occur if memory growth is set after device
+                # initialization
                 print(f"Error setting GPU memory growth: {e}. Falling back to CPU.")
                 return "CPU"
         else:
             print(
-                "No GPU devices found despite TensorFlow being built with CUDA. Using CPU."
+                "No GPU devices found despite TensorFlow ",
+                "being built with CUDA. Using CPU.",
             )
             return "CPU"
     else:

--- a/src/vtt/visualization/history_plot.py
+++ b/src/vtt/visualization/history_plot.py
@@ -10,9 +10,10 @@ accuracy, etc.) over epochs. These plots are useful for diagnosing issues like
 overfitting, underfitting, and convergence behavior.
 """
 
+from typing import Sequence, Tuple
+
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-from typing import Tuple, Sequence
 from tensorflow.keras.callbacks import History
 
 

--- a/src/vtt/visualization/history_plot.py
+++ b/src/vtt/visualization/history_plot.py
@@ -20,7 +20,7 @@ def plot_training_history(
     history: History,
     metrics: Sequence[str] = ("loss",),
     figsize: Tuple[int, int] = (8, 4),
-    grid: bool = False
+    grid: bool = False,
 ) -> None:
     """
     Plot training and validation metrics from a Keras History object.


### PR DESCRIPTION
- Added `isort` and `flake8` to manual pre-commit hooks
- Updated `README` formatting
- Added new notebook `modeling_usage_example_updated.ipynb`
- Updated `pyproject.toml` tooling for `black` and `flake8`
- Added `build_raw_captions_dict_from_csv` and `load_captions_dict` functions to `caption_preprocess.py`
- Updated `load_split_datasets` in `data_loader.py` to compile image ids with each split
- Added `evaluate_model` function to `evaluate.py`
- Updated `train.py` to handle changes to `data_loader.py`
- `plot_training_history` was updated to handle single epochs
- Entire repository was reformatted according to pep8 with flake8 linting and black code formatting